### PR TITLE
We can't use the name `init`, so let's call it `create`.

### DIFF
--- a/lib/xgit/repository/on_disk.ex
+++ b/lib/xgit/repository/on_disk.ex
@@ -15,6 +15,9 @@ defmodule Xgit.Repository.OnDisk do
 
   Analogous to [`git init`](https://git-scm.com/docs/git-init).
 
+  **NOTE:** We use the name `create` here so as to avoid a naming conflict with
+  the `GenServer` callback named `init/1`.
+
   ## Options
 
   * `:work_dir` (required): Top-level working directory. A `.git` directory is
@@ -30,6 +33,6 @@ defmodule Xgit.Repository.OnDisk do
 
   Will raise `File.Error` or similar if unable to create the directory.
   """
-  # @spec init([work_dir: String.t]) :: :ok
-  defdelegate init(opts), to: Xgit.Repository.OnDisk.Init
+  @spec create(work_dir: String.t()) :: :ok
+  defdelegate create(opts), to: Xgit.Repository.OnDisk.Create
 end

--- a/lib/xgit/repository/on_disk/create.ex
+++ b/lib/xgit/repository/on_disk/create.ex
@@ -1,12 +1,12 @@
-defmodule Xgit.Repository.OnDisk.Init do
+defmodule Xgit.Repository.OnDisk.Create do
   @moduledoc false
-  # Implements Xgit.Repository.OnDisk.init/1.
+  # Implements Xgit.Repository.OnDisk.create/1.
 
-  def init(opts) when is_list(opts) do
+  def create(opts) when is_list(opts) do
     work_dir = Keyword.get(opts, :work_dir)
 
     unless is_binary(work_dir) do
-      raise ArgumentError, "Xgit.Repository.OnDisk.init/1: :work_dir must be a file path"
+      raise ArgumentError, "Xgit.Repository.OnDisk.create/1: :work_dir must be a file path"
     end
 
     work_dir
@@ -19,7 +19,7 @@ defmodule Xgit.Repository.OnDisk.Init do
   defp assert_not_exists!(path) do
     if File.exists?(path) do
       raise ArgumentError,
-            "Xgit.Repository.OnDisk.init/1: :work_dir must be a directory that doesn't already exist"
+            "Xgit.Repository.OnDisk.create/1: :work_dir must be a directory that doesn't already exist"
     else
       path
     end

--- a/test/xgit/repository/on_disk/create_test.exs
+++ b/test/xgit/repository/on_disk/create_test.exs
@@ -1,19 +1,19 @@
-defmodule Xgit.Repository.OnDisk.InitTest do
+defmodule Xgit.Repository.OnDisk.CreateTest do
   use Xgit.GitInitTestCase, async: true
 
   alias Xgit.Repository.OnDisk
 
   import FolderDiff
 
-  describe "init/1" do
+  describe "create/1" do
     test "happy path matches command-line git", %{ref: ref, xgit: xgit} do
-      assert :ok = OnDisk.init(work_dir: xgit)
+      assert :ok = OnDisk.create(work_dir: xgit)
       assert_folders_are_equal(ref, xgit)
     end
 
     test "error: no work_dir" do
       assert_raise ArgumentError, fn ->
-        OnDisk.init([])
+        OnDisk.create([])
       end
     end
 
@@ -21,7 +21,7 @@ defmodule Xgit.Repository.OnDisk.InitTest do
       File.mkdir_p!(xgit)
 
       assert_raise ArgumentError, fn ->
-        OnDisk.init(work_dir: xgit)
+        OnDisk.create(work_dir: xgit)
       end
     end
   end


### PR DESCRIPTION
## Changes in This Pull Request
Avoid a naming conflict by referring to the operation as `create`, not `init`.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] There is test coverage for all changes.
- [ ] ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
