### PR TITLE
Rename Xgit.Plumbing.ObjectType to Xgit.Core.ObjectType.

### DIFF
--- a/lib/xgit/core/object_type.ex
+++ b/lib/xgit/core/object_type.ex
@@ -1,4 +1,4 @@
-defmodule Xgit.Plumbing.ObjectType do
+defmodule Xgit.Core.ObjectType do
   @moduledoc ~S"""
   Describes the known git object types.
 
@@ -30,8 +30,8 @@ defmodule Xgit.Plumbing.ObjectType do
 
   defmacro __using__(opts) do
     quote location: :keep, bind_quoted: [opts: opts] do
-      alias Xgit.Plumbing.ObjectType
-      import Xgit.Plumbing.ObjectType, only: [is_object_type: 1]
+      alias Xgit.Core.ObjectType
+      import Xgit.Core.ObjectType, only: [is_object_type: 1]
     end
   end
 end

--- a/test/xgit/core/object_type_test.exs
+++ b/test/xgit/core/object_type_test.exs
@@ -1,6 +1,6 @@
-defmodule Xgit.Plumbing.ObjectTypeTest do
+defmodule Xgit.Core.ObjectTypeTest do
   use ExUnit.Case, async: true
-  use Xgit.Plumbing.ObjectType
+  use Xgit.Core.ObjectType
 
   @object_types [:blob, :tree, :commit, :tag]
 


### PR DESCRIPTION
## Changes in This Pull Request
Thinking that the core data model modules should be named `Xgit.Core.*`.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] There is test coverage for all changes.
- [ ] ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
