### PR TITLE
Define a protocol for reading object content from various sources.

### DIFF
--- a/lib/xgit/core/content_source.ex
+++ b/lib/xgit/core/content_source.ex
@@ -1,0 +1,38 @@
+defprotocol Xgit.Core.ContentSource do
+  @moduledoc ~S"""
+  Protocol used for reading object content from various sources.
+  """
+
+  @typedoc ~S"""
+  Any value for which `ContentSource` protocol is implemented.
+  """
+  @type t :: term
+
+  @doc ~S"""
+  Calculate the length (in bytes) of the content.
+  """
+  @spec length(content :: t) :: non_neg_integer
+  def length(content)
+
+  @doc ~S"""
+  Return a stream which can be used for reading the content.
+  """
+  @spec stream(content :: t) :: Enumerable.t()
+  def stream(content)
+end
+
+defimpl Xgit.Core.ContentSource, for: List do
+  @impl true
+  def length(list), do: Enum.count(list)
+
+  @impl true
+  def stream(list), do: list
+end
+
+defimpl Xgit.Core.ContentSource, for: BitString do
+  @impl true
+  def length(s), do: byte_size(s)
+
+  @impl true
+  def stream(s), do: :binary.bin_to_list(s)
+end

--- a/test/xgit/core/content_source_test.exs
+++ b/test/xgit/core/content_source_test.exs
@@ -1,0 +1,27 @@
+defmodule Xgit.Core.ContentSourceTest do
+  use ExUnit.Case, async: true
+
+  alias Xgit.Core.ContentSource
+
+  describe "implementation for list" do
+    test "length/1" do
+      assert ContentSource.length('1234') == 4
+    end
+
+    test "stream/1" do
+      assert ContentSource.stream('1234') == '1234'
+    end
+  end
+
+  describe "implementation for string" do
+    test "length/1" do
+      assert ContentSource.length("1234") == 4
+      assert ContentSource.length("1ü34") == 5
+    end
+
+    test "stream/1" do
+      assert ContentSource.stream("1234") == '1234'
+      assert ContentSource.stream("1ü34") == [49, 195, 188, 51, 52]
+    end
+  end
+end


### PR DESCRIPTION
## Changes in This Pull Request
Define `Xgit.Core.ContentSource` protocol and implement it for bytelist and `String`.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] There is test coverage for all changes.
- [ ] ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
