### PR TITLE
Initial happy path for Xgit.Plumbing.HashObject.

### DIFF
--- a/lib/xgit/plumbing/hash_object.ex
+++ b/lib/xgit/plumbing/hash_object.ex
@@ -13,20 +13,27 @@ defmodule Xgit.Plumbing.HashObject do
 
   ## Options
 
-  * `:type`: the object's type (default: `:blob`)
-  * `:content`: how to obtain the content (see `Xgit.Core.ContentSource`)
+  `:content`: how to obtain the content
+    * Type: `Xgit.Core.ContentSource`
+    * _REQUIRED_
+
+  `:type`: the object's type
+    * Type: `Xgit.Core.ObjectType`
+    * Default: `:blob`
+    * See [`-t` option on `git hash-object`](https://git-scm.com/docs/git-hash-object#Documentation/git-hash-object.txt--tlttypegt)
 
   ## Return Value
 
-  The object's ID.
+  The object's ID. (See `Xgit.Core.ObjectId`.)
   """
   @spec run(type: ObjectType.t() | nil, content: ContentSource.t()) :: ObjectID.t()
   def run(opts) when is_list(opts) do
-    repo = Keyword.get(opts, :repository)
+    # repo = Keyword.get(opts, :repository)
 
     opts
     |> Object.new()
-    |> apply_filters(repo)
+    # (repo)
+    |> apply_filters(nil)
     |> annotate_with_size()
     |> validate_content()
     |> assign_object_id()

--- a/test/xgit/plumbing/hash_object_test.exs
+++ b/test/xgit/plumbing/hash_object_test.exs
@@ -11,5 +11,17 @@ defmodule Xgit.Plumbing.HashObjectTest do
       assert HashObject.run(content: "test content\n") ==
                "d670460b4b4aece5915caf5c68d12f560a9fe3e4"
     end
+
+    test "error: :content missing" do
+      assert_raise ArgumentError, "Xgit.Core.Object.new/1: :content is missing", fn ->
+        HashObject.run([])
+      end
+    end
+
+    test "error: :type invalid" do
+      assert_raise ArgumentError, "Xgit.Core.Object.new/1: type :bogus is invalid", fn ->
+        HashObject.run(content: "test content\n", type: :bogus)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Changes in This Pull Request
Can now derive the correct ID for an object with no repo available.

(Where "correct" = matches the behavior from command-line `git`.)

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] There is test coverage for all changes.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
