### PR TITLE
HashObject can now generate an ID from a content source that streams.

### DIFF
--- a/test/xgit/plumbing/hash_object_test.exs
+++ b/test/xgit/plumbing/hash_object_test.exs
@@ -1,6 +1,7 @@
 defmodule Xgit.Plumbing.HashObjectTest do
   use ExUnit.Case, async: true
 
+  alias Xgit.Core.FileContentSource
   alias Xgit.Plumbing.HashObject
 
   describe "run/1" do
@@ -10,6 +11,24 @@ defmodule Xgit.Plumbing.HashObjectTest do
 
       assert HashObject.run(content: "test content\n") ==
                "d670460b4b4aece5915caf5c68d12f560a9fe3e4"
+    end
+
+    test "happy path: deriving SHA hash (large file on disk) with no repo" do
+      Temp.track!()
+      path = Temp.path!()
+
+      content =
+        1..1000
+        |> Enum.map(fn _ -> "foobar" end)
+        |> Enum.join()
+
+      File.write!(path, content)
+
+      {output, 0} = System.cmd("git", ["hash-object", path])
+      expected_object_id = String.trim(output)
+
+      fcs = FileContentSource.new(path)
+      assert HashObject.run(content: fcs) == expected_object_id
     end
 
     test "error: :content missing" do


### PR DESCRIPTION
## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] There is test coverage for all changes.
- [ ] ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
