### PR TITLE
Fix vestigal file name.

### DIFF
--- a/test/xgit/core/file_content_source_test.exs
+++ b/test/xgit/core/file_content_source_test.exs
@@ -1,4 +1,4 @@
-defmodule Xgit.Core.ContentSource.FileTest do
+defmodule Xgit.Core.FileContentSourceTest do
   use ExUnit.Case, async: true
 
   alias Xgit.Core.ContentSource


### PR DESCRIPTION
## Changes in This Pull Request
Test module for `FileContentSource` had a name left over from an earlier version of the module. Fixed.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [ ] ~All applicable changes have been documented.~ _n/a_
- [ ] ~There is test coverage for all changes.~ _n/a_
- [ ] ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
