### PR TITLE
Add validate? option to HashObject.

### DIFF
--- a/lib/xgit/plumbing/hash_object.ex
+++ b/lib/xgit/plumbing/hash_object.ex
@@ -9,6 +9,7 @@ defmodule Xgit.Plumbing.HashObject do
   alias Xgit.Core.Object
   alias Xgit.Core.ObjectId
   alias Xgit.Core.ObjectType
+  alias Xgit.Core.ValidateObject
 
   @doc ~S"""
   Computes an object ID and optionally writes that into the repository's object store.
@@ -23,13 +24,20 @@ defmodule Xgit.Plumbing.HashObject do
   `:type`: the object's type
     * Type: `Xgit.Core.ObjectType`
     * Default: `:blob`
-    * See [`-t` option on `git hash-object`](https://git-scm.com/docs/git-hash-object#Documentation/git-hash-object.txt--tlttypegt)
+    * See [`-t` option on `git hash-object`](https://git-scm.com/docs/git-hash-object#Documentation/git-hash-object.txt--tlttypegt).
+
+  `:validate?`: `true` to verify that the object is valid for `:type`
+    * Type: boolean
+    * Default: `true`
+    * This is the inverse of the [`--literally` option on `git hash-object`](https://git-scm.com/docs/git-hash-object#Documentation/git-hash-object.txt---literally).
 
   ## Return Value
 
-  The object's ID. (See `Xgit.Core.ObjectId`.)
+  `{:ok, object_id}` if the object could be validated and assigned an ID.
+  `{:error, "reason"}` if unable.
   """
-  @spec run(content :: ContentSource.t(), type: ObjectType.t() | nil) :: ObjectID.t()
+  @spec run(content :: ContentSource.t(), type: ObjectType.t() | nil) ::
+          {:ok, ObjectID.t()} | {:error, reason :: String.t()}
   def run(content, opts \\ []) when not is_nil(content) and is_list(opts) do
     type = Keyword.get(opts, :type, :blob)
 
@@ -37,14 +45,21 @@ defmodule Xgit.Plumbing.HashObject do
       raise ArgumentError, "Xgit.Plumbing.HashObject.run/2: type #{inspect(type)} is invalid"
     end
 
+    validate? = Keyword.get(opts, :validate?, true)
+
+    unless is_boolean(validate?) do
+      raise ArgumentError,
+            "Xgit.Plumbing.HashObject.run/2: validate? #{inspect(validate?)} is invalid"
+    end
+
     repo = nil
     # Keyword.get(opts, :repository)
 
-    %Object{content: content, type: Keyword.get(opts, :type, :blob)}
+    %Object{content: content, type: type}
     |> apply_filters(repo)
     |> annotate_with_size()
-    |> validate_content()
     |> assign_object_id()
+    |> validate_content(validate?)
     |> maybe_write_to_repo(opts)
     |> result(opts)
   end
@@ -63,19 +78,33 @@ defmodule Xgit.Plumbing.HashObject do
   defp annotate_with_size(%Object{content: content} = object),
     do: %{object | size: ContentSource.length(content)}
 
-  defp validate_content(object) do
-    # TO DO: Add content validation per object type.
-    # Allow this to be bypassed.
-    object
+  defp validate_content(%Object{type: :blob} = object, _validate?), do: {:ok, object}
+  defp validate_content(object, false = _validate?), do: {:ok, object}
+
+  defp validate_content(%Object{content: content} = object, _validate?) when is_list(content) do
+    case ValidateObject.check(object) do
+      :ok -> {:ok, object}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp validate_content(%Object{content: content} = object, _validate?) do
+    validate_content(
+      %{object | content: content |> ContentSource.stream() |> Enum.to_list() |> Enum.concat()},
+      true
+    )
   end
 
   defp assign_object_id(%Object{content: content, type: type} = object),
     do: %{object | id: ObjectId.calculate_id(content, type)}
 
-  defp maybe_write_to_repo(object, _opts) do
+  defp maybe_write_to_repo({:ok, object}, _opts) do
     # TO DO: Pass the object through to repo to write it to disk.
-    object
+    {:ok, object}
   end
 
-  defp result(%Object{id: id}, _opts), do: id
+  defp maybe_write_to_repo({:error, reason}, _opts), do: {:error, reason}
+
+  defp result({:ok, %Object{id: id}}, _opts), do: {:ok, id}
+  defp result({:error, reason}, _opts), do: {:error, reason}
 end

--- a/test/xgit/plumbing/hash_object_test.exs
+++ b/test/xgit/plumbing/hash_object_test.exs
@@ -9,8 +9,7 @@ defmodule Xgit.Plumbing.HashObjectTest do
       # $ echo 'test content' | git hash-object --stdin
       # d670460b4b4aece5915caf5c68d12f560a9fe3e4
 
-      assert HashObject.run("test content\n") ==
-               "d670460b4b4aece5915caf5c68d12f560a9fe3e4"
+      assert {:ok, "d670460b4b4aece5915caf5c68d12f560a9fe3e4"} = HashObject.run("test content\n")
     end
 
     test "happy path: deriving SHA hash (large file on disk) with no repo" do
@@ -27,8 +26,62 @@ defmodule Xgit.Plumbing.HashObjectTest do
       {output, 0} = System.cmd("git", ["hash-object", path])
       expected_object_id = String.trim(output)
 
-      fcs = FileContentSource.new(path)
-      assert HashObject.run(fcs) == expected_object_id
+      assert {:ok, ^expected_object_id} =
+               path
+               |> FileContentSource.new()
+               |> HashObject.run()
+    end
+
+    test "happy path: validate content (content is valid)" do
+      Temp.track!()
+      path = Temp.path!()
+
+      content = ~C"""
+      tree be9bfa841874ccc9f2ef7c48d0c76226f89b7189
+      author A. U. Thor <author@localhost> 1 +0000
+      committer A. U. Thor <author@localhost> 1 +0000
+      """
+
+      File.write(path, content)
+
+      {output, 0} = System.cmd("git", ["hash-object", "-t", "commit", path])
+      expected_object_id = String.trim(output)
+
+      assert {:ok, ^expected_object_id} =
+               path
+               |> FileContentSource.new()
+               |> HashObject.run(type: :commit)
+    end
+
+    test "validate?: false skips validation" do
+      Temp.track!()
+      path = Temp.path!()
+
+      content = ~C"""
+      trie be9bfa841874ccc9f2ef7c48d0c76226f89b7189
+      author A. U. Thor <author@localhost> 1 +0000
+      committer A. U. Thor <author@localhost> 1 +0000
+      """
+
+      File.write(path, content)
+
+      {output, 0} = System.cmd("git", ["hash-object", "--literally", "-t", "commit", path])
+      expected_object_id = String.trim(output)
+
+      assert {:ok, ^expected_object_id} =
+               path
+               |> FileContentSource.new()
+               |> HashObject.run(type: :commit, validate?: false)
+    end
+
+    test "error: validate content (content is invalid)" do
+      content = ~C"""
+      trie be9bfa841874ccc9f2ef7c48d0c76226f89b7189
+      author A. U. Thor <author@localhost> 1 +0000
+      committer A. U. Thor <author@localhost> 1 +0000
+      """
+
+      assert {:error, "no tree header"} = HashObject.run(content, type: :commit)
     end
 
     test "error: content nil" do
@@ -41,6 +94,14 @@ defmodule Xgit.Plumbing.HashObjectTest do
       assert_raise ArgumentError, "Xgit.Plumbing.HashObject.run/2: type :bogus is invalid", fn ->
         HashObject.run("test content\n", type: :bogus)
       end
+    end
+
+    test "error: :validate? invalid" do
+      assert_raise ArgumentError,
+                   ~s(Xgit.Plumbing.HashObject.run/2: validate? "yes" is invalid),
+                   fn ->
+                     HashObject.run("test content\n", validate?: "yes")
+                   end
     end
   end
 end


### PR DESCRIPTION
## Changes in This Pull Request
Adds object validation to `Xgit.Plumbing.HashObject`.

Defaults to `true`, but you can use `validate?: false` to bypass validation.

Also change return options to `:ok` / `:error` tuples.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] There is test coverage for all changes.
- [ ] ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- [ ] ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- [ ] ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
