### PR TITLE
Reimplement Xgit.Repository.OnDisk.create to have an :ok / :error tuple result.

### DIFF
--- a/lib/xgit/repository/on_disk.ex
+++ b/lib/xgit/repository/on_disk.ex
@@ -48,21 +48,17 @@ defmodule Xgit.Repository.OnDisk do
   _NOTE:_ We use the name `create` here so as to avoid a naming conflict with
   `c:GenServer.init/1`.
 
-  ## Options
+  ## Parameters
 
-  * `:work_dir` (required): Top-level working directory. A `.git` directory is
-    created inside this directory.
+  `work_dir` (String) is the top-level working directory. A `.git` directory is
+  created inside this directory.
 
   ## Return Value
 
-  `:ok`
+  `:ok` if created successfully.
 
-  ## Errors
-
-  Will raise `ArgumentError` if options are incomplete or incorrect.
-
-  Will raise `File.Error` or similar if unable to create the directory.
+  `{:error, "reason"}` if not.
   """
-  @spec create!(work_dir: String.t()) :: :ok
-  defdelegate create!(opts), to: Xgit.Repository.OnDisk.Create
+  @spec create(work_dir :: String.t()) :: :ok | {:error, reason :: String.t()}
+  defdelegate create(work_dir), to: Xgit.Repository.OnDisk.Create
 end

--- a/test/xgit/repository/on_disk/create_test.exs
+++ b/test/xgit/repository/on_disk/create_test.exs
@@ -7,22 +7,21 @@ defmodule Xgit.Repository.OnDisk.CreateTest do
 
   describe "create/1" do
     test "happy path matches command-line git", %{ref: ref, xgit: xgit} do
-      assert :ok = OnDisk.create!(work_dir: xgit)
+      assert :ok = OnDisk.create(xgit)
       assert_folders_are_equal(ref, xgit)
     end
 
     test "error: no work_dir" do
-      assert_raise ArgumentError, fn ->
-        OnDisk.create!([])
+      assert_raise FunctionClauseError, fn ->
+        OnDisk.create(nil)
       end
     end
 
     test "error: work dir exists already", %{xgit: xgit} do
       File.mkdir_p!(xgit)
 
-      assert_raise ArgumentError, fn ->
-        OnDisk.create!(work_dir: xgit)
-      end
+      assert {:error, "work_dir must be a directory that doesn't already exist"} =
+               OnDisk.create(xgit)
     end
   end
 end

--- a/test/xgit/repository/on_disk_test.exs
+++ b/test/xgit/repository/on_disk_test.exs
@@ -8,7 +8,7 @@ defmodule Xgit.Repository.OnDiskTest do
 
   describe "start_link/1" do
     test "happy path: starts and is valid", %{xgit: xgit} do
-      assert :ok = OnDisk.create!(work_dir: xgit)
+      assert :ok = OnDisk.create(xgit)
 
       assert {:ok, repo} = OnDisk.start_link(work_dir: xgit)
       assert is_pid(repo)
@@ -17,7 +17,7 @@ defmodule Xgit.Repository.OnDiskTest do
     end
 
     test "handles unknown message", %{xgit: xgit} do
-      assert :ok = OnDisk.create!(work_dir: xgit)
+      assert :ok = OnDisk.create(xgit)
       assert {:ok, repo} = OnDisk.start_link(work_dir: xgit)
 
       assert capture_log(fn ->


### PR DESCRIPTION
## Changes in This Pull Request
Rethinking all APIs to be in line with Elixir conventions. (Fewer exceptions: good.)

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] There is test coverage for all changes.
- [ ] ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- [ ] ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- [ ] ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
