### PR TITLE
Xgit.Repository.OnDisk now tracks git_dir as part of its state.

### DIFF
--- a/lib/xgit/repository/on_disk.ex
+++ b/lib/xgit/repository/on_disk.ex
@@ -35,7 +35,7 @@ defmodule Xgit.Repository.OnDisk do
   def init(opts) when is_list(opts) do
     # TO DO: Be smarter about bare repos and non-standard git_dir locations.
     # https://github.com/elixir-git/xgit/issues/44
-    
+
     with {:work_dir_arg, work_dir} when is_binary(work_dir) <-
            {:work_dir_arg, Keyword.get(opts, :work_dir)},
          {:work_dir, true} <- {:work_dir, File.dir?(work_dir)},

--- a/lib/xgit/repository/on_disk.ex
+++ b/lib/xgit/repository/on_disk.ex
@@ -33,6 +33,9 @@ defmodule Xgit.Repository.OnDisk do
 
   @impl true
   def init(opts) when is_list(opts) do
+    # TO DO: Be smarter about bare repos and non-standard git_dir locations.
+    # https://github.com/elixir-git/xgit/issues/44
+    
     with {:work_dir_arg, work_dir} when is_binary(work_dir) <-
            {:work_dir_arg, Keyword.get(opts, :work_dir)},
          {:work_dir, true} <- {:work_dir, File.dir?(work_dir)},

--- a/test/xgit/repository/on_disk_test.exs
+++ b/test/xgit/repository/on_disk_test.exs
@@ -29,5 +29,21 @@ defmodule Xgit.Repository.OnDiskTest do
       Process.flag(:trap_exit, true)
       assert {:error, :missing_arguments} = OnDisk.start_link([])
     end
+
+    test "error: work_dir doesn't exist", %{xgit: xgit} do
+      Process.flag(:trap_exit, true)
+
+      assert {:error, :work_dir_doesnt_exist} =
+               OnDisk.start_link(work_dir: Path.join(xgit, "random"))
+    end
+
+    test "error: git_dir doesn't exist", %{xgit: xgit} do
+      Process.flag(:trap_exit, true)
+
+      temp_dir = Path.join(xgit, "blah")
+      File.mkdir_p!(temp_dir)
+
+      assert {:error, :git_dir_doesnt_exist} = OnDisk.start_link(work_dir: temp_dir)
+    end
   end
 end


### PR DESCRIPTION
## Changes in This Pull Request
`Xgit.Repository.OnDisk` now tracks `git_dir` as part of its state.

Related: #44 we're not very smart about _where_ that directory is located.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [ ] ~All applicable changes have been documented.~ _n/a_
- [x] There is test coverage for all changes.
- [ ] ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- [ ] ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
