### PR TITLE
Implement Xgit.Repository.put_loose_object/2.

### DIFF
--- a/lib/xgit/repository/on_disk.ex
+++ b/lib/xgit/repository/on_disk.ex
@@ -70,4 +70,8 @@ defmodule Xgit.Repository.OnDisk do
   """
   @spec create(work_dir :: String.t()) :: :ok | {:error, reason :: String.t()}
   defdelegate create(work_dir), to: Xgit.Repository.OnDisk.Create
+
+  @impl true
+  defdelegate handle_put_loose_object(state, object),
+    to: Xgit.Repository.OnDisk.PutLooseObject
 end

--- a/lib/xgit/repository/on_disk/put_loose_object.ex
+++ b/lib/xgit/repository/on_disk/put_loose_object.ex
@@ -23,9 +23,8 @@ defmodule Xgit.Repository.OnDisk.PutLooseObject do
       {:mkdir, _} ->
         {:error, :cant_create_dir, state}
 
-      x ->
-        IO.inspect(x, label: "unknown error")
-        {:error, :unknown}
+      {:file, {:error, :eexist}} ->
+        {:error, :object_exists, state}
     end
   end
 
@@ -49,10 +48,10 @@ defmodule Xgit.Repository.OnDisk.PutLooseObject do
   defp deflate_content(file, z, content) do
     content
     |> ContentSource.stream()
-    |> Stream.chunk_every(2048)
     |> Stream.each(fn chunk ->
-      deflate_and_write_bytes(file, z, chunk)
+      deflate_and_write_bytes(file, z, [chunk])
     end)
+    |> Stream.run()
   end
 
   defp deflate_and_write_bytes(file, z, bytes, flush \\ :none) do

--- a/lib/xgit/repository/on_disk/put_loose_object.ex
+++ b/lib/xgit/repository/on_disk/put_loose_object.ex
@@ -1,0 +1,67 @@
+defmodule Xgit.Repository.OnDisk.PutLooseObject do
+  @moduledoc false
+  # Implements Xgit.Repository.OnDisk.handle_put_loose_object/2.
+
+  alias Xgit.Core.ContentSource
+  alias Xgit.Core.Object
+
+  @spec handle_put_loose_object(state :: any, object :: Object.t()) ::
+          {:ok, state :: any} | {:error, reason :: String.t(), state :: any}
+  def handle_put_loose_object(%{git_dir: git_dir} = state, %Object{id: id} = object) do
+    object_dir = Path.join([git_dir, "objects", String.slice(id, 0, 2)])
+    path = Path.join(object_dir, String.slice(id, 2, 38))
+
+    with {:mkdir, :ok} <-
+           {:mkdir, File.mkdir_p(object_dir)},
+         {:file, {:ok, :ok}} <-
+           {:file,
+            File.open(path, [:write, :binary, :exclusive], fn file_pid ->
+              deflate_and_write(file_pid, object)
+            end)} do
+      {:ok, state}
+    else
+      {:mkdir, _} ->
+        {:error, :cant_create_dir, state}
+
+      x ->
+        IO.inspect(x, label: "unknown error")
+        {:error, :unknown}
+    end
+  end
+
+  defp deflate_and_write(file, %Object{type: type, size: size, content: content}) do
+    z = :zlib.open()
+    :ok = :zlib.deflateInit(z, 1)
+
+    deflate_and_write_bytes(file, z, '#{type} #{size}')
+    deflate_and_write_bytes(file, z, [0])
+
+    if is_list(content) do
+      deflate_and_write_bytes(file, z, content, :finish)
+    else
+      deflate_content(file, z, content)
+      deflate_and_write_bytes(file, z, [], :finish)
+    end
+
+    :zlib.deflateEnd(z)
+  end
+
+  defp deflate_content(file, z, content) do
+    content
+    |> ContentSource.stream()
+    |> Stream.chunk_every(2048)
+    |> Stream.each(fn chunk ->
+      deflate_and_write_bytes(file, z, chunk)
+    end)
+  end
+
+  defp deflate_and_write_bytes(file, z, bytes, flush \\ :none) do
+    compressed =
+      z
+      |> :zlib.deflate(bytes, flush)
+      |> Enum.join()
+      |> :binary.bin_to_list()
+
+    IO.write(file, compressed)
+  end
+end

--- a/test/xgit/repository/on_disk/put_loose_object_test.exs
+++ b/test/xgit/repository/on_disk/put_loose_object_test.exs
@@ -1,0 +1,44 @@
+defmodule Xgit.Repository.OnDisk.PutLooseObjectTest do
+  use Xgit.GitInitTestCase, async: true
+
+  alias Xgit.Core.Object
+  alias Xgit.Repository
+  alias Xgit.Repository.OnDisk
+
+  import FolderDiff
+
+  describe "put_loose_object/2" do
+    @test_content 'test content\n'
+    @test_content_id "d670460b4b4aece5915caf5c68d12f560a9fe3e4"
+
+    test "happy path matches command-line git", %{ref: ref, xgit: xgit} do
+      Temp.track!()
+      path = Temp.path!()
+      File.write!(path, "test content\n")
+
+      {output, 0} = System.cmd("git", ["hash-object", "-w", path], cd: ref)
+      assert String.trim(output) == @test_content_id
+
+      assert :ok = OnDisk.create(xgit)
+      assert {:ok, repo} = OnDisk.start_link(work_dir: xgit)
+
+      object = %Object{type: :blob, content: @test_content, size: 13, id: @test_content_id}
+      assert :ok = Repository.put_loose_object(repo, object)
+
+      assert_folders_are_equal(ref, xgit)
+    end
+
+    # test "error: no work_dir" do
+    #   assert_raise FunctionClauseError, fn ->
+    #     OnDisk.create(nil)
+    #   end
+    # end
+    #
+    # test "error: work dir exists already", %{xgit: xgit} do
+    #   File.mkdir_p!(xgit)
+    #
+    #   assert {:error, "work_dir must be a directory that doesn't already exist"} =
+    #            OnDisk.create(xgit)
+    # end
+  end
+end

--- a/test/xgit/repository/on_disk/put_loose_object_test.exs
+++ b/test/xgit/repository/on_disk/put_loose_object_test.exs
@@ -1,6 +1,8 @@
 defmodule Xgit.Repository.OnDisk.PutLooseObjectTest do
   use Xgit.GitInitTestCase, async: true
 
+  alias Xgit.Core.ContentSource
+  alias Xgit.Core.FileContentSource
   alias Xgit.Core.Object
   alias Xgit.Repository
   alias Xgit.Repository.OnDisk
@@ -11,7 +13,7 @@ defmodule Xgit.Repository.OnDisk.PutLooseObjectTest do
     @test_content 'test content\n'
     @test_content_id "d670460b4b4aece5915caf5c68d12f560a9fe3e4"
 
-    test "happy path matches command-line git", %{ref: ref, xgit: xgit} do
+    test "happy path matches command-line git (small file)", %{ref: ref, xgit: xgit} do
       Temp.track!()
       path = Temp.path!()
       File.write!(path, "test content\n")
@@ -28,17 +30,56 @@ defmodule Xgit.Repository.OnDisk.PutLooseObjectTest do
       assert_folders_are_equal(ref, xgit)
     end
 
-    # test "error: no work_dir" do
-    #   assert_raise FunctionClauseError, fn ->
-    #     OnDisk.create(nil)
-    #   end
-    # end
-    #
-    # test "error: work dir exists already", %{xgit: xgit} do
-    #   File.mkdir_p!(xgit)
-    #
-    #   assert {:error, "work_dir must be a directory that doesn't already exist"} =
-    #            OnDisk.create(xgit)
-    # end
+    test "happy path matches command-line git (large file)", %{ref: ref, xgit: xgit} do
+      Temp.track!()
+      path = Temp.path!()
+
+      content =
+        1..1000
+        |> Enum.map(fn _ -> "foobar" end)
+        |> Enum.join()
+
+      File.write!(path, content)
+
+      {output, 0} = System.cmd("git", ["hash-object", "-w", path], cd: ref)
+      content_id = String.trim(output)
+
+      assert :ok = OnDisk.create(xgit)
+      assert {:ok, repo} = OnDisk.start_link(work_dir: xgit)
+
+      fcs = FileContentSource.new(path)
+      object = %Object{type: :blob, content: fcs, size: ContentSource.length(fcs), id: content_id}
+      assert :ok = Repository.put_loose_object(repo, object)
+
+      assert_folders_are_equal(ref, xgit)
+    end
+
+    test "error: can't create objects dir", %{xgit: xgit} do
+      assert :ok = OnDisk.create(xgit)
+      assert {:ok, repo} = OnDisk.start_link(work_dir: xgit)
+
+      objects_dir = Path.join([xgit, ".git", "objects", String.slice(@test_content_id, 0, 2)])
+      File.mkdir_p!(Path.join([xgit, ".git", "objects"]))
+      File.write!(objects_dir, "sand in the gears")
+
+      object = %Object{type: :blob, content: @test_content, size: 13, id: @test_content_id}
+      assert {:error, :cant_create_dir} = Repository.put_loose_object(repo, object)
+    end
+
+    test "error: object exists already", %{xgit: xgit} do
+      assert :ok = OnDisk.create(xgit)
+      assert {:ok, repo} = OnDisk.start_link(work_dir: xgit)
+
+      objects_dir = Path.join([xgit, ".git", "objects", String.slice(@test_content_id, 0, 2)])
+      File.mkdir_p!(objects_dir)
+
+      File.write!(
+        Path.join(objects_dir, String.slice(@test_content_id, 2, 38)),
+        "sand in the gears"
+      )
+
+      object = %Object{type: :blob, content: @test_content, size: 13, id: @test_content_id}
+      assert {:error, :object_exists} = Repository.put_loose_object(repo, object)
+    end
   end
 end


### PR DESCRIPTION
## Changes in This Pull Request
Adds a `put_loose_object/2` function to `Repository` (and corresponding pass-through to the repo process and behaviour).

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] There is test coverage for all changes.
- [ ] ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- [ ] ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- [ ] ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
