### PR TITLE
Implement Xgit.Repository.get_object/2.

### DIFF
--- a/lib/xgit/repository/on_disk.ex
+++ b/lib/xgit/repository/on_disk.ex
@@ -72,6 +72,10 @@ defmodule Xgit.Repository.OnDisk do
   defdelegate create(work_dir), to: Xgit.Repository.OnDisk.Create
 
   @impl true
+  defdelegate handle_get_object(state, object_id),
+    to: Xgit.Repository.OnDisk.GetObject
+
+  @impl true
   defdelegate handle_put_loose_object(state, object),
     to: Xgit.Repository.OnDisk.PutLooseObject
 end

--- a/lib/xgit/repository/on_disk/get_object.ex
+++ b/lib/xgit/repository/on_disk/get_object.ex
@@ -13,9 +13,8 @@ defmodule Xgit.Repository.OnDisk.GetObject do
     # TO DO: Look for object in packs.
     # https://github.com/elixir-git/xgit/issues/52
 
-    with %Object{} = object <- find_loose_object(git_dir, object_id) do
-      {:ok, object, state}
-    else
+    case find_loose_object(git_dir, object_id) do
+      %Object{} = object -> {:ok, object, state}
       {:error, :not_found} -> {:error, :not_found, state}
       {:error, :invalid_object} -> {:error, :invalid_object, state}
     end

--- a/lib/xgit/repository/on_disk/get_object.ex
+++ b/lib/xgit/repository/on_disk/get_object.ex
@@ -1,0 +1,88 @@
+defmodule Xgit.Repository.OnDisk.GetObject do
+  @moduledoc false
+  # Implements Xgit.Repository.OnDisk.handle_get_object/2.
+
+  alias Xgit.Core.Object
+  alias Xgit.Util.RawParseUtils
+  alias Xgit.Util.UnzipStream
+
+  @spec handle_get_object(state :: any, object_id :: ObjectId.t()) ::
+          {:ok, object :: Object.t(), state :: any} | {:error, reason :: String.t(), state :: any}
+  def handle_get_object(%{git_dir: git_dir} = state, object_id) do
+    # Currently only checks for loose objects.
+    # TO DO: Look for object in packs.
+    # https://github.com/elixir-git/xgit/issues/52
+
+    with %Object{} = object <- find_loose_object(git_dir, object_id) do
+      {:ok, object, state}
+    else
+      {:error, :not_found} -> {:error, :not_found, state}
+      {:error, :invalid_object} -> {:error, :invalid_object, state}
+    end
+  end
+
+  defp find_loose_object(git_dir, object_id) do
+    loose_object_path =
+      Path.join([
+        git_dir,
+        "objects",
+        String.slice(object_id, 0, 2),
+        String.slice(object_id, 2, 38)
+      ])
+
+    with {:exists?, true} <- {:exists?, File.regular?(loose_object_path)},
+         {:header, type, length} <- read_loose_object_prefix(loose_object_path) do
+      loose_file_to_object(type, length, object_id, loose_object_path)
+    else
+      {:exists?, false} -> {:error, :not_found}
+      :invalid_header -> {:error, :invalid_object}
+    end
+  end
+
+  defp read_loose_object_prefix(path) do
+    path
+    |> File.stream!([:binary], 100)
+    |> UnzipStream.unzip()
+    |> Stream.take(100)
+    |> Stream.take_while(&(&1 != 0))
+    |> Enum.to_list()
+    |> Enum.split_while(&(&1 != ?\s))
+    |> parse_prefix_and_length()
+  rescue
+    ErlangError -> :invalid_header
+  end
+
+  @known_types ['blob', 'tag', 'tree', 'commit']
+  @type_to_atom %{'blob' => :blob, 'tag' => :tag, 'tree' => :tree, 'commit' => :commit}
+
+  defp parse_prefix_and_length({type, length}) when type in @known_types,
+    do: parse_length(@type_to_atom[type], length)
+
+  defp parse_prefix_and_length(_), do: :invalid_header
+
+  defp parse_length(_type, ' '), do: :invalid_header
+
+  defp parse_length(type, [?\s | length]) do
+    case RawParseUtils.parse_base_10(length) do
+      {length, []} when is_integer(length) and length >= 0 -> {:header, type, length}
+      _ -> :invalid_header
+    end
+  end
+
+  defp parse_length(_type, _length), do: :invalid_header
+
+  defp loose_file_to_object(type, length, object_id, path)
+       when is_atom(type) and is_integer(length) do
+    %Object{
+      type: type,
+      size: length,
+      id: object_id,
+      content:
+        path
+        |> File.stream!([:binary])
+        |> UnzipStream.unzip()
+        |> Stream.drop_while(&(&1 != 0))
+        |> Stream.drop(1)
+    }
+  end
+end

--- a/test/xgit/repository/on_disk/get_object_test.exs
+++ b/test/xgit/repository/on_disk/get_object_test.exs
@@ -1,0 +1,119 @@
+defmodule Xgit.Repository.OnDisk.GetObjectTest do
+  use Xgit.GitInitTestCase, async: true
+
+  alias Xgit.Core.Object
+  alias Xgit.Repository
+  alias Xgit.Repository.OnDisk
+
+  describe "get_object/2" do
+    test "happy path: can read from command-line git (small file)", %{ref: ref} do
+      Temp.track!()
+      path = Temp.path!()
+      File.write!(path, "test content\n")
+
+      {output, 0} = System.cmd("git", ["hash-object", "-w", path], cd: ref)
+      test_content_id = String.trim(output)
+
+      assert {:ok, repo} = OnDisk.start_link(work_dir: ref)
+
+      assert {:ok,
+              %Object{type: :blob, content: test_content, size: 13, id: ^test_content_id} = object} =
+               Repository.get_object(repo, test_content_id)
+
+      assert Enum.to_list(test_content) == 'test content\n'
+    end
+
+    test "happy path: can read from command-line git (large file)", %{ref: ref} do
+      Temp.track!()
+      path = Temp.path!()
+
+      content =
+        1..1000
+        |> Enum.map(fn _ -> "foobar" end)
+        |> Enum.join()
+
+      File.write!(path, content)
+
+      {output, 0} = System.cmd("git", ["hash-object", "-w", path], cd: ref)
+      content_id = String.trim(output)
+
+      assert {:ok, repo} = OnDisk.start_link(work_dir: ref)
+
+      assert {:ok,
+              %Object{type: :blob, content: test_content, size: 6000, id: ^content_id} = object} =
+               Repository.get_object(repo, content_id)
+
+      test_content_str =
+        test_content
+        |> Enum.to_list()
+        |> to_string()
+
+      assert test_content_str == content
+    end
+
+    test "error: no such file", %{ref: ref} do
+      assert {:ok, repo} = OnDisk.start_link(work_dir: ref)
+
+      assert {:error, :not_found} =
+               Repository.get_object(repo, "5cb5d77be2d92c7368038dac67e648a69e0a654d")
+    end
+
+    test "error: invalid object (not ZIP compressed)", %{xgit: xgit} do
+      assert_zip_data_is_invalid(xgit, "blob ")
+    end
+
+    test "error: invalid object (ZIP compressed, but incomplete)", %{xgit: xgit} do
+      # "blob "
+      assert_zip_data_is_invalid(xgit, <<120, 1, 75, 202, 201, 79, 82, 0, 0, 5, 208, 1, 192>>)
+    end
+
+    test "error: invalid object (ZIP compressed, but invalid object type)", %{xgit: xgit} do
+      # "blog 13\0"
+      assert_zip_data_is_invalid(
+        xgit,
+        <<120, 1, 75, 202, 201, 79, 87, 48, 52, 102, 0, 0, 12, 34, 2, 41>>
+      )
+    end
+
+    test "error: invalid object (ZIP compressed, but invalid object type 2)", %{xgit: xgit} do
+      # "blobx 1234\0"
+      assert_zip_data_is_invalid(
+        xgit,
+        <<120, 1, 75, 202, 201, 79, 170, 80, 48, 52, 50, 54, 97, 0, 0, 22, 54, 3, 2>>
+      )
+    end
+
+    test "error: invalid object (ZIP compressed, but invalid length)", %{xgit: xgit} do
+      # "blob 13 \0" (extra space)
+      assert_zip_data_is_invalid(
+        xgit,
+        <<120, 1, 75, 202, 201, 79, 82, 48, 52, 86, 96, 0, 0, 14, 109, 2, 68>>
+      )
+    end
+
+    test "error: invalid object (ZIP compressed, but invalid length 2)", %{xgit: xgit} do
+      # "blob 12x34\0"
+      assert_zip_data_is_invalid(
+        xgit,
+        <<120, 1, 75, 202, 201, 79, 82, 48, 52, 170, 48, 54, 97, 0, 0, 21, 81, 3, 2>>
+      )
+    end
+
+    test "error: invalid object (ZIP compressed, but no length)", %{xgit: xgit} do
+      # "blob \0" (space, but no length)
+      assert_zip_data_is_invalid(xgit, <<120, 1, 75, 202, 201, 79, 82, 96, 0, 0, 7, 144, 1, 192>>)
+    end
+  end
+
+  defp assert_zip_data_is_invalid(xgit, data) do
+    path = Path.join([xgit, ".git", "objects", "5c"])
+    File.mkdir_p!(path)
+
+    File.write!(Path.join(path, "b5d77be2d92c7368038dac67e648a69e0a654d"), data)
+
+    assert {:ok, repo} = OnDisk.start_link(work_dir: xgit)
+
+    assert {:error, :invalid_object} =
+             Repository.get_object(repo, "5cb5d77be2d92c7368038dac67e648a69e0a654d")
+  end
+end


### PR DESCRIPTION
## Changes in This Pull Request
Adds Repository implementation for retrieving objects from the content store.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] There is test coverage for all changes.
- [ ] ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- [ ] ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
