### PR TITLE
Change all {:error, (string)} tuples to be {:error, (atom)}.

### DIFF
--- a/lib/xgit/core/validate_object.ex
+++ b/lib/xgit/core/validate_object.ex
@@ -78,6 +78,8 @@ defmodule Xgit.Core.ValidateObject do
 
   `:ok` if the object is successfully validated.
 
+  `{:error, :invalid_type}` if the object's type is unknown.
+
   `{:error, :no_tree_header}` if the object is a commit but does not contain
   a valid tree header.
 
@@ -93,7 +95,7 @@ defmodule Xgit.Core.ValidateObject do
   def check(%Object{type: :commit} = object, _opts), do: check_commit(object)
   def check(%Object{type: :tag} = object, _opts), do: check_tag(object)
   def check(%Object{type: :tree} = object, opts), do: check_tree(object, opts)
-  def check(%Object{type: type}, _opts), do: {:error, "invalid type #{inspect(type)}"}
+  def check(%Object{type: type}, _opts), do: {:error, :invalid_type}
 
   # -- commit specifics --
 

--- a/lib/xgit/core/validate_object.ex
+++ b/lib/xgit/core/validate_object.ex
@@ -117,7 +117,7 @@ defmodule Xgit.Core.ValidateObject do
 
   `{:error, :null_sha1}` if the object is a tree and one of the object IDs is all zeros.
 
-  `{:error, :truncated_in_mode}` if the object is a tree and one of the file modes is incomplete.
+  `{:error, :invalid_mode}` if the object is a tree and one of the file modes is incomplete.
 
   `{:error, "reason"}` if the object can not be validated.
   """
@@ -240,16 +240,16 @@ defmodule Xgit.Core.ValidateObject do
     end
   end
 
-  defp check_file_mode([], _mode), do: {:error, :truncated_in_mode}
+  defp check_file_mode([], _mode), do: {:error, :invalid_mode}
 
   defp check_file_mode([?\s | data], mode), do: {:ok, mode, data}
 
-  defp check_file_mode([?0 | _data], 0), do: {:error, "mode starts with '0'"}
+  defp check_file_mode([?0 | _data], 0), do: {:error, :invalid_mode}
 
   defp check_file_mode([c | data], mode) when c >= ?0 and c <= ?7,
     do: check_file_mode(data, mode * 8 + (c - ?0))
 
-  defp check_file_mode([_c | _data], _mode), do: {:error, "invalid mode character"}
+  defp check_file_mode([_c | _data], _mode), do: {:error, :invalid_mode}
 
   defp path_and_object_id(data), do: Enum.split_while(data, &(&1 != 0))
 

--- a/lib/xgit/core/validate_object.ex
+++ b/lib/xgit/core/validate_object.ex
@@ -81,6 +81,9 @@ defmodule Xgit.Core.ValidateObject do
   `{:error, :no_tree_header}` if the object is a commit but does not contain
   a valid tree header.
 
+  `{:error, :invalid_tree}` if the object is a commit but the tree object ID
+  is invalid.
+
   `{:error, "reason"}` if the object can not be validated.
   """
   @spec check(object :: Object.t(), opts :: Keyword.t()) :: :ok | {:error, reason :: String.t()}
@@ -105,7 +108,7 @@ defmodule Xgit.Core.ValidateObject do
       :ok
     else
       {:tree, _} -> {:error, :no_tree_header}
-      {:tree_id, _} -> {:error, "invalid tree"}
+      {:tree_id, _} -> {:error, :invalid_tree}
       {:parents, _} -> {:error, "invalid parent"}
       {:author, _} -> {:error, "no author"}
       {:author_id, why} when is_binary(why) -> {:error, why}

--- a/lib/xgit/core/validate_object.ex
+++ b/lib/xgit/core/validate_object.ex
@@ -117,6 +117,8 @@ defmodule Xgit.Core.ValidateObject do
 
   `{:error, :null_sha1}` if the object is a tree and one of the object IDs is all zeros.
 
+  `{:error, :truncated_in_mode}` if the object is a tree and one of the file modes is incomplete.
+
   `{:error, "reason"}` if the object can not be validated.
   """
   @spec check(object :: Object.t(), opts :: Keyword.t()) :: :ok | {:error, reason :: String.t()}
@@ -238,7 +240,7 @@ defmodule Xgit.Core.ValidateObject do
     end
   end
 
-  defp check_file_mode([], _mode), do: {:error, "truncated in mode"}
+  defp check_file_mode([], _mode), do: {:error, :truncated_in_mode}
 
   defp check_file_mode([?\s | data], mode), do: {:ok, mode, data}
 

--- a/lib/xgit/core/validate_object.ex
+++ b/lib/xgit/core/validate_object.ex
@@ -118,6 +118,9 @@ defmodule Xgit.Core.ValidateObject do
   `{:error, :null_sha1}` if the object is a tree and one of the object IDs is all zeros.
 
   `{:error, :invalid_mode}` if the object is a tree and one of the file modes is incomplete.
+
+  See also error responses from `Xgit.Core.ValidatePath.check_path/2` and
+  `Xgit.Core.ValidatePath.check_path_segment/2`.
   """
   @spec check(object :: Object.t(), opts :: Keyword.t()) :: :ok | {:error, reason :: String.t()}
   def check(object, opts \\ [])

--- a/lib/xgit/core/validate_object.ex
+++ b/lib/xgit/core/validate_object.ex
@@ -97,6 +97,8 @@ defmodule Xgit.Core.ValidateObject do
 
   `{:error, :invalid_object}` if the object is a tag but the object ID is invalid.
 
+  `{:error, :no_type_header}` if the object is a tag but there is no `type` header.
+
   `{:error, "reason"}` if the object can not be validated.
   """
   @spec check(object :: Object.t(), opts :: Keyword.t()) :: :ok | {:error, reason :: String.t()}
@@ -156,7 +158,7 @@ defmodule Xgit.Core.ValidateObject do
     else
       {:object, _} -> {:error, :no_object_header}
       {:object_id, _} -> {:error, :invalid_object}
-      {:type, _} -> {:error, "no type header"}
+      {:type, _} -> {:error, :no_type_header}
       {:tag, _} -> {:error, "no tag header"}
       {:tagger, _} -> {:error, "invalid tagger"}
     end

--- a/lib/xgit/core/validate_object.ex
+++ b/lib/xgit/core/validate_object.ex
@@ -109,6 +109,9 @@ defmodule Xgit.Core.ValidateObject do
   `{:error, :duplicate_entry_names}` if the object is a tree and contains duplicate
   entry names.
 
+  `{:error, :incorrectly_sorted}` if the object is a tree and the entries are not
+  in alphabetical order.
+
   `{:error, "reason"}` if the object can not be validated.
   """
   @spec check(object :: Object.t(), opts :: Keyword.t()) :: :ok | {:error, reason :: String.t()}
@@ -224,7 +227,7 @@ defmodule Xgit.Core.ValidateObject do
       {:path_split, _} -> {:error, :truncated_in_name}
       {:path_valid, {:error, reason}} -> {:error, reason}
       {:duplicate, _} -> {:error, :duplicate_entry_names}
-      {:sorted, _} -> {:error, "incorrectly sorted"}
+      {:sorted, _} -> {:error, :incorrectly_sorted}
       {:object_id_length, _} -> {:error, "truncated in object id"}
       {:object_id_null, _} -> {:error, "entry points to null SHA-1"}
     end

--- a/lib/xgit/core/validate_object.ex
+++ b/lib/xgit/core/validate_object.ex
@@ -78,6 +78,9 @@ defmodule Xgit.Core.ValidateObject do
 
   `:ok` if the object is successfully validated.
 
+  `{:error, :no_tree_header}` if the object is a commit but does not contain
+  a valid tree header.
+
   `{:error, "reason"}` if the object can not be validated.
   """
   @spec check(object :: Object.t(), opts :: Keyword.t()) :: :ok | {:error, reason :: String.t()}
@@ -101,7 +104,7 @@ defmodule Xgit.Core.ValidateObject do
          {:committer_id, data} when is_list(data) <- {:committer_id, check_person_ident(data)} do
       :ok
     else
-      {:tree, _} -> {:error, "no tree header"}
+      {:tree, _} -> {:error, :no_tree_header}
       {:tree_id, _} -> {:error, "invalid tree"}
       {:parents, _} -> {:error, "invalid parent"}
       {:author, _} -> {:error, "no author"}

--- a/lib/xgit/core/validate_object.ex
+++ b/lib/xgit/core/validate_object.ex
@@ -159,7 +159,7 @@ defmodule Xgit.Core.ValidateObject do
       {:object, _} -> {:error, :no_object_header}
       {:object_id, _} -> {:error, :invalid_object}
       {:type, _} -> {:error, :no_type_header}
-      {:tag, _} -> {:error, "no tag header"}
+      {:tag, _} -> {:error, :no_tag_header}
       {:tagger, _} -> {:error, "invalid tagger"}
     end
   end

--- a/lib/xgit/core/validate_object.ex
+++ b/lib/xgit/core/validate_object.ex
@@ -115,6 +115,8 @@ defmodule Xgit.Core.ValidateObject do
   `{:error, :truncated_in_object_id}` if the object is a tree and one of the object IDs
   is invalid.
 
+  `{:error, :null_sha1}` if the object is a tree and one of the object IDs is all zeros.
+
   `{:error, "reason"}` if the object can not be validated.
   """
   @spec check(object :: Object.t(), opts :: Keyword.t()) :: :ok | {:error, reason :: String.t()}
@@ -232,7 +234,7 @@ defmodule Xgit.Core.ValidateObject do
       {:duplicate, _} -> {:error, :duplicate_entry_names}
       {:sorted, _} -> {:error, :incorrectly_sorted}
       {:object_id_length, _} -> {:error, :truncated_in_object_id}
-      {:object_id_null, _} -> {:error, "entry points to null SHA-1"}
+      {:object_id_null, _} -> {:error, :null_sha1}
     end
   end
 

--- a/lib/xgit/core/validate_object.ex
+++ b/lib/xgit/core/validate_object.ex
@@ -91,6 +91,8 @@ defmodule Xgit.Core.ValidateObject do
 
   `{:error, :no_author}` if the object is a commit but there is no `author` header.
 
+  `{:error, :no_committer}` if the object is a commit but there is no `committer` header.
+
   `{:error, "reason"}` if the object can not be validated.
   """
   @spec check(object :: Object.t(), opts :: Keyword.t()) :: :ok | {:error, reason :: String.t()}
@@ -119,7 +121,7 @@ defmodule Xgit.Core.ValidateObject do
       {:parents, _} -> {:error, :invalid_parent}
       {:author, _} -> {:error, :no_author}
       {:author_id, why} when is_binary(why) -> {:error, why}
-      {:committer, _} -> {:error, "no committer"}
+      {:committer, _} -> {:error, :no_committer}
       {:committer_id, why} when is_binary(why) -> {:error, why}
     end
   end

--- a/lib/xgit/core/validate_object.ex
+++ b/lib/xgit/core/validate_object.ex
@@ -106,6 +106,9 @@ defmodule Xgit.Core.ValidateObject do
 
   `{:error, :truncated_in_name}` if the object is a tree but one of the file names is incomplete.
 
+  `{:error, :duplicate_entry_names}` if the object is a tree and contains duplicate
+  entry names.
+
   `{:error, "reason"}` if the object can not be validated.
   """
   @spec check(object :: Object.t(), opts :: Keyword.t()) :: :ok | {:error, reason :: String.t()}
@@ -220,7 +223,7 @@ defmodule Xgit.Core.ValidateObject do
       {:file_mode, _} -> {:error, :invalid_file_mode}
       {:path_split, _} -> {:error, :truncated_in_name}
       {:path_valid, {:error, reason}} -> {:error, reason}
-      {:duplicate, _} -> {:error, "duplicate entry names"}
+      {:duplicate, _} -> {:error, :duplicate_entry_names}
       {:sorted, _} -> {:error, "incorrectly sorted"}
       {:object_id_length, _} -> {:error, "truncated in object id"}
       {:object_id_null, _} -> {:error, "entry points to null SHA-1"}

--- a/lib/xgit/core/validate_object.ex
+++ b/lib/xgit/core/validate_object.ex
@@ -95,6 +95,8 @@ defmodule Xgit.Core.ValidateObject do
 
   `{:error, :no_object_header}` if the object is a tag but there is no `object` header.
 
+  `{:error, :invalid_object}` if the object is a tag but the object ID is invalid.
+
   `{:error, "reason"}` if the object can not be validated.
   """
   @spec check(object :: Object.t(), opts :: Keyword.t()) :: :ok | {:error, reason :: String.t()}
@@ -153,7 +155,7 @@ defmodule Xgit.Core.ValidateObject do
       :ok
     else
       {:object, _} -> {:error, :no_object_header}
-      {:object_id, _} -> {:error, "invalid object"}
+      {:object_id, _} -> {:error, :invalid_object}
       {:type, _} -> {:error, "no type header"}
       {:tag, _} -> {:error, "no tag header"}
       {:tagger, _} -> {:error, "invalid tagger"}

--- a/lib/xgit/core/validate_object.ex
+++ b/lib/xgit/core/validate_object.ex
@@ -118,8 +118,6 @@ defmodule Xgit.Core.ValidateObject do
   `{:error, :null_sha1}` if the object is a tree and one of the object IDs is all zeros.
 
   `{:error, :invalid_mode}` if the object is a tree and one of the file modes is incomplete.
-
-  `{:error, "reason"}` if the object can not be validated.
   """
   @spec check(object :: Object.t(), opts :: Keyword.t()) :: :ok | {:error, reason :: String.t()}
   def check(object, opts \\ [])

--- a/lib/xgit/core/validate_object.ex
+++ b/lib/xgit/core/validate_object.ex
@@ -102,6 +102,8 @@ defmodule Xgit.Core.ValidateObject do
   `{:error, :invalid_tagger}` if the object is a tag but one of the `tagger` headers
   is invalid.
 
+  `{:error, :invalid_file_mode}` if the object is a tree but one of the file modes is invalid.
+
   `{:error, "reason"}` if the object can not be validated.
   """
   @spec check(object :: Object.t(), opts :: Keyword.t()) :: :ok | {:error, reason :: String.t()}
@@ -213,7 +215,7 @@ defmodule Xgit.Core.ValidateObject do
       )
     else
       {:file_mode, {:error, reason}} -> {:error, reason}
-      {:file_mode, _} -> {:error, "invalid file mode"}
+      {:file_mode, _} -> {:error, :invalid_file_mode}
       {:path_split, _} -> {:error, "truncated in name"}
       {:path_valid, {:error, reason}} -> {:error, reason}
       {:duplicate, _} -> {:error, "duplicate entry names"}

--- a/lib/xgit/core/validate_object.ex
+++ b/lib/xgit/core/validate_object.ex
@@ -86,6 +86,9 @@ defmodule Xgit.Core.ValidateObject do
   `{:error, :invalid_tree}` if the object is a commit but the tree object ID
   is invalid.
 
+  `{:error, :invalid_parent}` if the object is a commit but one of the `parent`
+  headers is invalid.
+
   `{:error, "reason"}` if the object can not be validated.
   """
   @spec check(object :: Object.t(), opts :: Keyword.t()) :: :ok | {:error, reason :: String.t()}
@@ -95,7 +98,7 @@ defmodule Xgit.Core.ValidateObject do
   def check(%Object{type: :commit} = object, _opts), do: check_commit(object)
   def check(%Object{type: :tag} = object, _opts), do: check_tag(object)
   def check(%Object{type: :tree} = object, opts), do: check_tree(object, opts)
-  def check(%Object{type: type}, _opts), do: {:error, :invalid_type}
+  def check(%Object{type: _type}, _opts), do: {:error, :invalid_type}
 
   # -- commit specifics --
 
@@ -111,7 +114,7 @@ defmodule Xgit.Core.ValidateObject do
     else
       {:tree, _} -> {:error, :no_tree_header}
       {:tree_id, _} -> {:error, :invalid_tree}
-      {:parents, _} -> {:error, "invalid parent"}
+      {:parents, _} -> {:error, :invalid_parent}
       {:author, _} -> {:error, "no author"}
       {:author_id, why} when is_binary(why) -> {:error, why}
       {:committer, _} -> {:error, "no committer"}

--- a/lib/xgit/core/validate_object.ex
+++ b/lib/xgit/core/validate_object.ex
@@ -102,6 +102,19 @@ defmodule Xgit.Core.ValidateObject do
   `{:error, :invalid_tagger}` if the object is a tag but one of the `tagger` headers
   is invalid.
 
+  `{:error, :bad_date}` if the object is a tag or a commit but has a malformed date entry.
+
+  `{:error, :bad_email}` if the object is a tag or a commit but has a malformed e-mail address.
+
+  `{:error, :missing_email}` if the object is a tag or a commit but has a missing e-mail address
+  where one is expected.
+
+  `{:error, :missing_space_before_date}` if the object is a tag or a commit but
+  has no space preceding the place where a date is expected.
+
+  `{:error, :bad_time_zone}` if the object is a tag or a commit but has a malformed
+  time zone entry.
+
   `{:error, :invalid_file_mode}` if the object is a tree but one of the file modes is invalid.
 
   `{:error, :truncated_in_name}` if the object is a tree but one of the file names is incomplete.
@@ -147,9 +160,9 @@ defmodule Xgit.Core.ValidateObject do
       {:tree_id, _} -> {:error, :invalid_tree}
       {:parents, _} -> {:error, :invalid_parent}
       {:author, _} -> {:error, :no_author}
-      {:author_id, why} when is_binary(why) -> {:error, why}
+      {:author_id, why} when is_atom(why) -> {:error, why}
       {:committer, _} -> {:error, :no_committer}
-      {:committer_id, why} when is_binary(why) -> {:error, why}
+      {:committer_id, why} when is_atom(why) -> {:error, why}
     end
   end
 
@@ -316,11 +329,11 @@ defmodule Xgit.Core.ValidateObject do
          {:bad_timezone, {_tz, [?\n | next]}} <- {:bad_timezone, RawParseUtils.parse_base_10(tz)} do
       next
     else
-      {:missing_email, _} -> "missing email"
-      {:bad_email, _} -> "bad email"
-      {:missing_space_before_date, _} -> "missing space before date"
-      {:bad_date, _} -> "bad date"
-      {:bad_timezone, _} -> "bad time zone"
+      {:missing_email, _} -> :missing_email
+      {:bad_email, _} -> :bad_email
+      {:missing_space_before_date, _} -> :missing_space_before_date
+      {:bad_date, _} -> :bad_date
+      {:bad_timezone, _} -> :bad_time_zone
     end
   end
 

--- a/lib/xgit/core/validate_object.ex
+++ b/lib/xgit/core/validate_object.ex
@@ -104,6 +104,8 @@ defmodule Xgit.Core.ValidateObject do
 
   `{:error, :invalid_file_mode}` if the object is a tree but one of the file modes is invalid.
 
+  `{:error, :truncated_in_name}` if the object is a tree but one of the file names is incomplete.
+
   `{:error, "reason"}` if the object can not be validated.
   """
   @spec check(object :: Object.t(), opts :: Keyword.t()) :: :ok | {:error, reason :: String.t()}
@@ -216,7 +218,7 @@ defmodule Xgit.Core.ValidateObject do
     else
       {:file_mode, {:error, reason}} -> {:error, reason}
       {:file_mode, _} -> {:error, :invalid_file_mode}
-      {:path_split, _} -> {:error, "truncated in name"}
+      {:path_split, _} -> {:error, :truncated_in_name}
       {:path_valid, {:error, reason}} -> {:error, reason}
       {:duplicate, _} -> {:error, "duplicate entry names"}
       {:sorted, _} -> {:error, "incorrectly sorted"}

--- a/lib/xgit/core/validate_object.ex
+++ b/lib/xgit/core/validate_object.ex
@@ -99,6 +99,9 @@ defmodule Xgit.Core.ValidateObject do
 
   `{:error, :no_type_header}` if the object is a tag but there is no `type` header.
 
+  `{:error, :invalid_tagger}` if the object is a tag but one of the `tagger` headers
+  is invalid.
+
   `{:error, "reason"}` if the object can not be validated.
   """
   @spec check(object :: Object.t(), opts :: Keyword.t()) :: :ok | {:error, reason :: String.t()}
@@ -160,7 +163,7 @@ defmodule Xgit.Core.ValidateObject do
       {:object_id, _} -> {:error, :invalid_object}
       {:type, _} -> {:error, :no_type_header}
       {:tag, _} -> {:error, :no_tag_header}
-      {:tagger, _} -> {:error, "invalid tagger"}
+      {:tagger, _} -> {:error, :invalid_tagger}
     end
   end
 

--- a/lib/xgit/core/validate_object.ex
+++ b/lib/xgit/core/validate_object.ex
@@ -89,6 +89,8 @@ defmodule Xgit.Core.ValidateObject do
   `{:error, :invalid_parent}` if the object is a commit but one of the `parent`
   headers is invalid.
 
+  `{:error, :no_author}` if the object is a commit but there is no `author` header.
+
   `{:error, "reason"}` if the object can not be validated.
   """
   @spec check(object :: Object.t(), opts :: Keyword.t()) :: :ok | {:error, reason :: String.t()}
@@ -115,7 +117,7 @@ defmodule Xgit.Core.ValidateObject do
       {:tree, _} -> {:error, :no_tree_header}
       {:tree_id, _} -> {:error, :invalid_tree}
       {:parents, _} -> {:error, :invalid_parent}
-      {:author, _} -> {:error, "no author"}
+      {:author, _} -> {:error, :no_author}
       {:author_id, why} when is_binary(why) -> {:error, why}
       {:committer, _} -> {:error, "no committer"}
       {:committer_id, why} when is_binary(why) -> {:error, why}

--- a/lib/xgit/core/validate_object.ex
+++ b/lib/xgit/core/validate_object.ex
@@ -93,6 +93,8 @@ defmodule Xgit.Core.ValidateObject do
 
   `{:error, :no_committer}` if the object is a commit but there is no `committer` header.
 
+  `{:error, :no_object_header}` if the object is a tag but there is no `object` header.
+
   `{:error, "reason"}` if the object can not be validated.
   """
   @spec check(object :: Object.t(), opts :: Keyword.t()) :: :ok | {:error, reason :: String.t()}
@@ -150,7 +152,7 @@ defmodule Xgit.Core.ValidateObject do
          {:tagger, data} when is_list(data) <- {:tagger, maybe_match_tagger(data)} do
       :ok
     else
-      {:object, _} -> {:error, "no object header"}
+      {:object, _} -> {:error, :no_object_header}
       {:object_id, _} -> {:error, "invalid object"}
       {:type, _} -> {:error, "no type header"}
       {:tag, _} -> {:error, "no tag header"}

--- a/lib/xgit/core/validate_object.ex
+++ b/lib/xgit/core/validate_object.ex
@@ -112,6 +112,9 @@ defmodule Xgit.Core.ValidateObject do
   `{:error, :incorrectly_sorted}` if the object is a tree and the entries are not
   in alphabetical order.
 
+  `{:error, :truncated_in_object_id}` if the object is a tree and one of the object IDs
+  is invalid.
+
   `{:error, "reason"}` if the object can not be validated.
   """
   @spec check(object :: Object.t(), opts :: Keyword.t()) :: :ok | {:error, reason :: String.t()}
@@ -228,7 +231,7 @@ defmodule Xgit.Core.ValidateObject do
       {:path_valid, {:error, reason}} -> {:error, reason}
       {:duplicate, _} -> {:error, :duplicate_entry_names}
       {:sorted, _} -> {:error, :incorrectly_sorted}
-      {:object_id_length, _} -> {:error, "truncated in object id"}
+      {:object_id_length, _} -> {:error, :truncated_in_object_id}
       {:object_id_null, _} -> {:error, "entry points to null SHA-1"}
     end
   end

--- a/lib/xgit/core/validate_path.ex
+++ b/lib/xgit/core/validate_path.ex
@@ -76,13 +76,16 @@ defmodule Xgit.Core.ValidatePath do
 
   * `:ok` if the name is permissible given the constraints chosen above
   * `{:error, :invalid_name}` if the name is not permissible
-  * `{:error, "reason"}` if the name is not permissible
+  * `{:error, :empty_path}` if the name is empty
+  * `{:error, :absolute_path}` if the name starts with a `/`
+  * `{:error, :duplicate_slash}` if the name contains two `/` characters in a row
+  * `{:error, :trailing_slash}` if the name contains a trailing `/`
   """
   @spec check_path(path :: [byte], windows?: boolean, macosx?: boolean) :: result
   def check_path(path, opts \\ [])
 
-  def check_path([], opts) when is_list(opts), do: {:error, "empty path"}
-  def check_path([?/ | _], opts) when is_list(opts), do: {:error, "absolute path"}
+  def check_path([], opts) when is_list(opts), do: {:error, :empty_path}
+  def check_path([?/ | _], opts) when is_list(opts), do: {:error, :absolute_path}
 
   def check_path(path, opts) when is_list(path) and is_list(opts) do
     {first_segment, remaining_path} = Enum.split_while(path, &(&1 != ?/))
@@ -96,10 +99,10 @@ defmodule Xgit.Core.ValidatePath do
   defp check_remaining_path([], _opts), do: :ok
 
   defp check_remaining_path([?/], _opts),
-    do: {:error, "trailing '/'"}
+    do: {:error, :trailing_slash}
 
   defp check_remaining_path([?/, ?/ | _remainder], _opts),
-    do: {:error, "duplicate '/' characters in path"}
+    do: {:error, :duplicate_slash}
 
   defp check_remaining_path([?/ | remainder], opts), do: check_path(remainder, opts)
 

--- a/lib/xgit/core/validate_path.ex
+++ b/lib/xgit/core/validate_path.ex
@@ -75,6 +75,7 @@ defmodule Xgit.Core.ValidatePath do
   ## Return Values
 
   * `:ok` if the name is permissible given the constraints chosen above
+  * `{:error, :invalid_name}` if the name is not permissible
   * `{:error, "reason"}` if the name is not permissible
   """
   @spec check_path(path :: [byte], windows?: boolean, macosx?: boolean) :: result
@@ -118,6 +119,7 @@ defmodule Xgit.Core.ValidatePath do
   ## Return Values
 
   * `:ok` if the name is permissible given the constraints chosen above
+  * `{:error, :invalid_name}` if the name is not permissible
   * `{:error, "reason"}` if the name is not permissible
   """
   @spec check_path_segment(path :: [byte], windows?: boolean, macosx?: boolean) :: result
@@ -146,20 +148,20 @@ defmodule Xgit.Core.ValidatePath do
 
   defp refute_has_nil_bytes(path_segment) do
     if Enum.any?(path_segment, &(&1 == 0)),
-      do: {:error, "name contains byte 0x00"},
+      do: {:error, :invalid_name},
       else: :ok
   end
 
   defp refute_has_slash(path_segment) do
     if Enum.any?(path_segment, &(&1 == ?/)),
-      do: {:error, "name contains byte '/'"},
+      do: {:error, :invalid_name},
       else: :ok
   end
 
   defp check_windows_git_name(path_segment) do
     with 5 <- Enum.count(path_segment),
          'git~1' <- Enum.map(path_segment, &to_lower/1) do
-      {:error, "invalid name '#{path_segment}'"}
+      {:error, :invalid_name}
     else
       _ -> :ok
     end

--- a/lib/xgit/plumbing/hash_object.ex
+++ b/lib/xgit/plumbing/hash_object.ex
@@ -48,7 +48,7 @@ defmodule Xgit.Plumbing.HashObject do
   ## Return Value
 
   `{:ok, object_id}` if the object could be validated and assigned an ID.
-  `{:error, "reason"}` if unable.
+  `{:error, :reason}` if unable.
   """
   @spec run(content :: ContentSource.t(), type: ObjectType.t() | nil) ::
           {:ok, ObjectID.t()} | {:error, reason :: String.t()}

--- a/lib/xgit/plumbing/hash_object.ex
+++ b/lib/xgit/plumbing/hash_object.ex
@@ -42,13 +42,19 @@ defmodule Xgit.Plumbing.HashObject do
     * This option is meaningless if `:repo` is not specified.
     * See [`-w` option on `git hash-object`](https://git-scm.com/docs/git-hash-object#Documentation/git-hash-object.txt--w).
 
-  **TO DO:** There is no support, at present, for filters as defined in a
+  _TO DO:_ There is no support, at present, for filters as defined in a
   `.gitattributes` file. See [issue #18](https://github.com/elixir-git/xgit/issues/18).
 
-  ## Return Value
+  ## Return Values
 
   `{:ok, object_id}` if the object could be validated and assigned an ID.
-  `{:error, :reason}` if unable.
+
+  `{:error, :reason}` if unable. The relevant reason codes may come from:
+
+  * `Xgit.Core.ValidateObject.check/2`
+  * `Xgit.Core.ValidatePath.check_path/2`
+  * `Xgit.Core.ValidatePath.check_path_segment/2`.
+
   """
   @spec run(content :: ContentSource.t(), type: ObjectType.t() | nil) ::
           {:ok, ObjectID.t()} | {:error, reason :: String.t()}

--- a/lib/xgit/repository.ex
+++ b/lib/xgit/repository.ex
@@ -120,7 +120,7 @@ defmodule Xgit.Repository do
 
   `:ok` if written successfully.
 
-  `{:error, "reason"}` if unable to write the object.
+  `{:error, :reason}` if unable to write the object.
   """
   @spec put_loose_object(repository :: t, object :: Object.t()) ::
           :ok | {:error, reason :: String.t()}
@@ -136,7 +136,7 @@ defmodule Xgit.Repository do
 
   Should return `{:ok, state}` if written successfully.
 
-  Should return `{:error, "reason", state}` if unable to write the object.
+  Should return `{:error, :reason, state}` if unable to write the object.
   """
   @callback handle_put_loose_object(state :: any, object :: Object.t()) ::
               {:ok, state :: any} | {:error, reason :: String.t(), state :: any}

--- a/lib/xgit/repository/on_disk.ex
+++ b/lib/xgit/repository/on_disk.ex
@@ -66,7 +66,7 @@ defmodule Xgit.Repository.OnDisk do
 
   `:ok` if created successfully.
 
-  `{:error, "reason"}` if not.
+  `{:error, :work_dir_must_not_exist}` if `work_dir` already exists.
   """
   @spec create(work_dir :: String.t()) :: :ok | {:error, reason :: String.t()}
   defdelegate create(work_dir), to: Xgit.Repository.OnDisk.Create

--- a/lib/xgit/repository/on_disk/create.ex
+++ b/lib/xgit/repository/on_disk/create.ex
@@ -11,7 +11,7 @@ defmodule Xgit.Repository.OnDisk.Create do
 
   defp assert_not_exists(path) do
     if File.exists?(path),
-      do: {:error, "work_dir must be a directory that doesn't already exist"},
+      do: {:error, :work_dir_must_not_exist},
       else: {:ok, path}
   end
 

--- a/test/xgit/core/validate_object_test.exs
+++ b/test/xgit/core/validate_object_test.exs
@@ -786,7 +786,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: mode not supported mode 1" do
-      assert {:error, "invalid file mode"} =
+      assert {:error, :invalid_file_mode} =
                check(%Object{
                  type: :tree,
                  content: entry("1 a")
@@ -794,7 +794,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: mode not supported mode 2" do
-      assert {:error, "invalid file mode"} =
+      assert {:error, :invalid_file_mode} =
                check(%Object{
                  type: :tree,
                  content: entry("170000 a")

--- a/test/xgit/core/validate_object_test.exs
+++ b/test/xgit/core/validate_object_test.exs
@@ -659,7 +659,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: null SHA-1 in tree entry" do
-      assert {:error, "entry points to null SHA-1"} =
+      assert {:error, :null_sha1} =
                check(%Object{
                  type: :tree,
                  content: '100644 A' ++ Enum.map(0..20, fn _ -> 0 end)

--- a/test/xgit/core/validate_object_test.exs
+++ b/test/xgit/core/validate_object_test.exs
@@ -516,7 +516,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: no type 4" do
-      assert {:error, "no tag header"} =
+      assert {:error, :no_tag_header} =
                check(%Object{
                  type: :tag,
                  content:
@@ -526,7 +526,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: no tag header 1" do
-      assert {:error, "no tag header"} =
+      assert {:error, :no_tag_header} =
                check(%Object{
                  type: :tag,
                  content: ~c"""
@@ -537,7 +537,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: no tag header 2" do
-      assert {:error, "no tag header"} =
+      assert {:error, :no_tag_header} =
                check(%Object{
                  type: :tag,
                  content:
@@ -548,7 +548,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: no tag header 3" do
-      assert {:error, "no tag header"} =
+      assert {:error, :no_tag_header} =
                check(%Object{
                  type: :tag,
                  content: ~c"""

--- a/test/xgit/core/validate_object_test.exs
+++ b/test/xgit/core/validate_object_test.exs
@@ -485,7 +485,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: no type 1" do
-      assert {:error, "no type header"} =
+      assert {:error, :no_type_header} =
                check(%Object{
                  type: :tag,
                  content: ~c"""
@@ -495,7 +495,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: no type 2" do
-      assert {:error, "no type header"} =
+      assert {:error, :no_type_header} =
                check(%Object{
                  type: :tag,
                  content:
@@ -505,7 +505,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: no type 3" do
-      assert {:error, "no type header"} =
+      assert {:error, :no_type_header} =
                check(%Object{
                  type: :tag,
                  content: ~c"""

--- a/test/xgit/core/validate_object_test.exs
+++ b/test/xgit/core/validate_object_test.exs
@@ -293,7 +293,7 @@ defmodule Xgit.Core.ValidateObjectTest do
       # Yes, really, we complain about author not being
       # found as the invalid parent line wasn't consumed.
 
-      assert {:error, "no author"} =
+      assert {:error, :no_author} =
                check(%Object{
                  type: :commit,
                  content: ~c"""
@@ -304,7 +304,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: no author" do
-      assert {:error, "no author"} =
+      assert {:error, :no_author} =
                check(%Object{
                  type: :commit,
                  content: ~c"""

--- a/test/xgit/core/validate_object_test.exs
+++ b/test/xgit/core/validate_object_test.exs
@@ -1037,7 +1037,7 @@ defmodule Xgit.Core.ValidateObjectTest do
 
     test "invalid: bad sorting" do
       Enum.each(@badly_sorted_trees, fn badly_sorted_names ->
-        assert {:error, "incorrectly sorted"} =
+        assert {:error, :incorrectly_sorted} =
                  check(%Object{
                    type: :tree,
                    content:

--- a/test/xgit/core/validate_object_test.exs
+++ b/test/xgit/core/validate_object_test.exs
@@ -315,7 +315,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: no committer 1" do
-      assert {:error, "no committer"} =
+      assert {:error, :no_committer} =
                check(%Object{
                  type: :commit,
                  content: ~c"""
@@ -326,7 +326,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: no committer 2" do
-      assert {:error, "no committer"} =
+      assert {:error, :no_committer} =
                check(%Object{
                  type: :commit,
                  content: ~c"""

--- a/test/xgit/core/validate_object_test.exs
+++ b/test/xgit/core/validate_object_test.exs
@@ -1014,7 +1014,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: tree truncated in name" do
-      assert {:error, "truncated in name"} =
+      assert {:error, :truncated_in_name} =
                check(%Object{
                  type: :tree,
                  content: '100644 b'

--- a/test/xgit/core/validate_object_test.exs
+++ b/test/xgit/core/validate_object_test.exs
@@ -1022,7 +1022,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: tree truncated in object ID" do
-      assert {:error, "truncated in object id"} =
+      assert {:error, :truncated_in_object_id} =
                check(%Object{
                  type: :tree,
                  content: '100644 b' ++ [0, 1, 2]

--- a/test/xgit/core/validate_object_test.exs
+++ b/test/xgit/core/validate_object_test.exs
@@ -738,7 +738,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: truncated in mode" do
-      assert {:error, :truncated_in_mode} =
+      assert {:error, :invalid_mode} =
                check(%Object{
                  type: :tree,
                  content: '1006'
@@ -746,7 +746,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: mode starts with zero 1" do
-      assert {:error, "mode starts with '0'"} =
+      assert {:error, :invalid_mode} =
                check(%Object{
                  type: :tree,
                  content: entry("0 a")
@@ -754,7 +754,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: mode starts with zero 2" do
-      assert {:error, "mode starts with '0'"} =
+      assert {:error, :invalid_mode} =
                check(%Object{
                  type: :tree,
                  content: entry("0100644 a")
@@ -762,7 +762,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: mode starts with zero 3" do
-      assert {:error, "mode starts with '0'"} =
+      assert {:error, :invalid_mode} =
                check(%Object{
                  type: :tree,
                  content: entry("040000 a")
@@ -770,7 +770,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: mode not octal 1" do
-      assert {:error, "invalid mode character"} =
+      assert {:error, :invalid_mode} =
                check(%Object{
                  type: :tree,
                  content: entry("8 a")
@@ -778,7 +778,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: mode not octal 2" do
-      assert {:error, "invalid mode character"} =
+      assert {:error, :invalid_mode} =
                check(%Object{
                  type: :tree,
                  content: entry("Z a")

--- a/test/xgit/core/validate_object_test.exs
+++ b/test/xgit/core/validate_object_test.exs
@@ -441,11 +441,11 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: no object 1" do
-      assert {:error, "no object header"} = check(%Object{type: :tag, content: []})
+      assert {:error, :no_object_header} = check(%Object{type: :tag, content: []})
     end
 
     test "invalid: no object 2" do
-      assert {:error, "no object header"} =
+      assert {:error, :no_object_header} =
                check(%Object{
                  type: :tag,
                  content: 'object\tbe9bfa841874ccc9f2ef7c48d0c76226f89b7189\n'
@@ -453,7 +453,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: no object 3" do
-      assert {:error, "no object header"} =
+      assert {:error, :no_object_header} =
                check(%Object{
                  type: :tag,
                  content: ~c"""

--- a/test/xgit/core/validate_object_test.exs
+++ b/test/xgit/core/validate_object_test.exs
@@ -207,7 +207,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: invalid tree 1" do
-      assert {:error, "invalid tree"} =
+      assert {:error, :invalid_tree} =
                check(%Object{
                  type: :commit,
                  content: ~c"""
@@ -217,7 +217,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: invalid tree 2" do
-      assert {:error, "invalid tree"} =
+      assert {:error, :invalid_tree} =
                check(%Object{
                  type: :commit,
                  content: ~c"""
@@ -227,7 +227,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: invalid tree 3" do
-      assert {:error, "invalid tree"} =
+      assert {:error, :invalid_tree} =
                check(%Object{
                  type: :commit,
                  content: ~c"""
@@ -237,7 +237,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: invalid tree 4" do
-      assert {:error, "invalid tree"} =
+      assert {:error, :invalid_tree} =
                check(%Object{
                  type: :commit,
                  content: ~c"""

--- a/test/xgit/core/validate_object_test.exs
+++ b/test/xgit/core/validate_object_test.exs
@@ -463,7 +463,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: no object 4" do
-      assert {:error, "invalid object"} =
+      assert {:error, :invalid_object} =
                check(%Object{
                  type: :tag,
                  content: ~c"""
@@ -473,7 +473,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: no object 5" do
-      assert {:error, "invalid object"} =
+      assert {:error, :invalid_object} =
                check(%Object{
                  type: :tag,
                  content: 'object be9bfa841874ccc9f2ef7c48d0c76226f89b7189 \n'
@@ -481,7 +481,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: no object 6" do
-      assert {:error, "invalid object"} = check(%Object{type: :tag, content: 'object be9'})
+      assert {:error, :invalid_object} = check(%Object{type: :tag, content: 'object be9'})
     end
 
     test "invalid: no type 1" do

--- a/test/xgit/core/validate_object_test.exs
+++ b/test/xgit/core/validate_object_test.exs
@@ -1049,7 +1049,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: duplicate file name" do
-      assert {:error, "duplicate entry names"} =
+      assert {:error, :duplicate_entry_names} =
                check(%Object{
                  type: :tree,
                  content: entry("100644 a") ++ entry("100644 a")
@@ -1057,7 +1057,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: duplicate tree name" do
-      assert {:error, "duplicate entry names"} =
+      assert {:error, :duplicate_entry_names} =
                check(%Object{
                  type: :tree,
                  content: entry("40000 a") ++ entry("40000 a")
@@ -1065,7 +1065,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: duplicate names 2" do
-      assert {:error, "duplicate entry names"} =
+      assert {:error, :duplicate_entry_names} =
                check(%Object{
                  type: :tree,
                  content: entry("100644 a") ++ entry("100755 a")
@@ -1073,7 +1073,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: duplicate names 3" do
-      assert {:error, "duplicate entry names"} =
+      assert {:error, :duplicate_entry_names} =
                check(%Object{
                  type: :tree,
                  content: entry("100644 a") ++ entry("40000 a")
@@ -1081,7 +1081,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: duplicate names 4" do
-      assert {:error, "duplicate entry names"} =
+      assert {:error, :duplicate_entry_names} =
                check(%Object{
                  type: :tree,
                  content:
@@ -1095,7 +1095,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: duplicate names 5 (Windows case folding)" do
-      assert {:error, "duplicate entry names"} =
+      assert {:error, :duplicate_entry_names} =
                check(
                  %Object{
                    type: :tree,
@@ -1106,7 +1106,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: duplicate names 6 (Mac case folding)" do
-      assert {:error, "duplicate entry names"} =
+      assert {:error, :duplicate_entry_names} =
                check(
                  %Object{
                    type: :tree,
@@ -1117,7 +1117,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: duplicate names 7 (MacOS denormalized names)" do
-      assert {:error, "duplicate entry names"} =
+      assert {:error, :duplicate_entry_names} =
                check(
                  %Object{
                    type: :tree,

--- a/test/xgit/core/validate_object_test.exs
+++ b/test/xgit/core/validate_object_test.exs
@@ -802,7 +802,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: name contains slash" do
-      assert {:error, "name contains byte '/'"} =
+      assert {:error, :invalid_name} =
                check(%Object{
                  type: :tree,
                  content: entry("100644 a/b")
@@ -997,9 +997,7 @@ defmodule Xgit.Core.ValidateObjectTest do
 
     test "invalid: tree name is variant of git~1" do
       Enum.each(@bad_dot_git_tilde_names, fn bad_name ->
-        expected_error = "invalid name '#{bad_name}'"
-
-        assert {:error, ^expected_error} =
+        assert {:error, :invalid_name} =
                  check(%Object{
                    type: :tree,
                    content: entry("100644 #{bad_name}")

--- a/test/xgit/core/validate_object_test.exs
+++ b/test/xgit/core/validate_object_test.exs
@@ -572,7 +572,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: invalid tagger header 1" do
-      assert {:error, "invalid tagger"} =
+      assert {:error, :invalid_tagger} =
                check(%Object{
                  type: :tag,
                  content:
@@ -584,7 +584,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: invalid tagger header 3" do
-      assert {:error, "invalid tagger"} =
+      assert {:error, :invalid_tagger} =
                check(%Object{
                  type: :tag,
                  content: ~c"""

--- a/test/xgit/core/validate_object_test.exs
+++ b/test/xgit/core/validate_object_test.exs
@@ -92,7 +92,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: corrupt author" do
-      assert {:error, "bad date"} =
+      assert {:error, :bad_date} =
                check(%Object{
                  type: :commit,
                  content: ~C"""
@@ -104,7 +104,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: corrupt committer" do
-      assert {:error, "bad date"} =
+      assert {:error, :bad_date} =
                check(%Object{
                  type: :commit,
                  content: ~C"""
@@ -338,7 +338,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: invalid author 1" do
-      assert {:error, "bad email"} =
+      assert {:error, :bad_email} =
                check(%Object{
                  type: :commit,
                  content: ~c"""
@@ -349,7 +349,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: invalid author 2" do
-      assert {:error, "missing email"} =
+      assert {:error, :missing_email} =
                check(%Object{
                  type: :commit,
                  content: ~c"""
@@ -360,7 +360,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: invalid author 3" do
-      assert {:error, "missing email"} =
+      assert {:error, :missing_email} =
                check(%Object{
                  type: :commit,
                  content: ~c"""
@@ -371,7 +371,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: invalid author 4" do
-      assert {:error, "bad date"} =
+      assert {:error, :bad_date} =
                check(%Object{
                  type: :commit,
                  content: ~c"""
@@ -382,7 +382,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: invalid author 5" do
-      assert {:error, "missing space before date"} =
+      assert {:error, :missing_space_before_date} =
                check(%Object{
                  type: :commit,
                  content: ~c"""
@@ -393,7 +393,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: invalid author 6" do
-      assert {:error, "bad date"} =
+      assert {:error, :bad_date} =
                check(%Object{
                  type: :commit,
                  content: ~c"""
@@ -404,7 +404,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: invalid author 7" do
-      assert {:error, "bad time zone"} =
+      assert {:error, :bad_time_zone} =
                check(%Object{
                  type: :commit,
                  content: ~c"""
@@ -415,7 +415,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: invalid committer" do
-      assert {:error, "bad email"} =
+      assert {:error, :bad_email} =
                check(%Object{
                  type: :commit,
                  content:

--- a/test/xgit/core/validate_object_test.exs
+++ b/test/xgit/core/validate_object_test.exs
@@ -738,7 +738,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: truncated in mode" do
-      assert {:error, "truncated in mode"} =
+      assert {:error, :truncated_in_mode} =
                check(%Object{
                  type: :tree,
                  content: '1006'

--- a/test/xgit/core/validate_object_test.exs
+++ b/test/xgit/core/validate_object_test.exs
@@ -55,7 +55,7 @@ defmodule Xgit.Core.ValidateObjectTest do
   @placeholder_object_id 0..19 |> Enum.to_list()
 
   test "invalid object type" do
-    assert {:error, "invalid type :bad"} = check(%Object{type: :bad, content: []})
+    assert {:error, :invalid_type} = check(%Object{type: :bad, content: []})
   end
 
   describe "check blob" do

--- a/test/xgit/core/validate_object_test.exs
+++ b/test/xgit/core/validate_object_test.exs
@@ -167,7 +167,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: no tree 1" do
-      assert {:error, "no tree header"} =
+      assert {:error, :no_tree_header} =
                check(%Object{
                  type: :commit,
                  content: ~C"""
@@ -177,7 +177,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: no tree 2" do
-      assert {:error, "no tree header"} =
+      assert {:error, :no_tree_header} =
                check(%Object{
                  type: :commit,
                  content: ~C"""
@@ -187,7 +187,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: no tree 3" do
-      assert {:error, "no tree header"} =
+      assert {:error, :no_tree_header} =
                check(%Object{
                  type: :commit,
                  content: ~C"""
@@ -197,7 +197,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: no tree 4" do
-      assert {:error, "no tree header"} =
+      assert {:error, :no_tree_header} =
                check(%Object{
                  type: :commit,
                  content: ~c"""

--- a/test/xgit/core/validate_object_test.exs
+++ b/test/xgit/core/validate_object_test.exs
@@ -247,7 +247,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: invalid parent 1" do
-      assert {:error, "invalid parent"} =
+      assert {:error, :invalid_parent} =
                check(%Object{
                  type: :commit,
                  content:
@@ -257,7 +257,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: invalid parent 2" do
-      assert {:error, "invalid parent"} =
+      assert {:error, :invalid_parent} =
                check(%Object{
                  type: :commit,
                  content: ~c"""
@@ -268,7 +268,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: invalid parent 3" do
-      assert {:error, "invalid parent"} =
+      assert {:error, :invalid_parent} =
                check(%Object{
                  type: :commit,
                  content: ~c"""
@@ -279,7 +279,7 @@ defmodule Xgit.Core.ValidateObjectTest do
     end
 
     test "invalid: invalid parent 4" do
-      assert {:error, "invalid parent"} =
+      assert {:error, :invalid_parent} =
                check(%Object{
                  type: :commit,
                  content: ~c"""

--- a/test/xgit/core/validate_path_test.exs
+++ b/test/xgit/core/validate_path_test.exs
@@ -125,17 +125,17 @@ defmodule Xgit.Core.ValidatePathTest do
 
   describe "check_path/2" do
     test "basic case: no platform checks" do
-      assert check_path('') == {:error, "empty path"}
+      assert check_path('') == {:error, :empty_path}
       assert check_path('a') == :ok
       assert check_path('a/b') == :ok
-      assert check_path('a//b') == {:error, "duplicate '/' characters in path"}
-      assert check_path('/a') == {:error, "absolute path"}
+      assert check_path('a//b') == {:error, :duplicate_slash}
+      assert check_path('/a') == {:error, :absolute_path}
       assert check_path('a\0b') == {:error, :invalid_name}
       assert check_path('ab/cd/ef') == :ok
 
-      assert check_path('ab/cd//ef') == {:error, "duplicate '/' characters in path"}
-      assert check_path('a/') == {:error, "trailing '/'"}
-      assert check_path('ab/cd/ef/') == {:error, "trailing '/'"}
+      assert check_path('ab/cd//ef') == {:error, :duplicate_slash}
+      assert check_path('a/') == {:error, :trailing_slash}
+      assert check_path('ab/cd/ef/') == {:error, :trailing_slash}
     end
 
     test "Windows variations on .git (applies to all platforms)" do

--- a/test/xgit/core/validate_path_test.exs
+++ b/test/xgit/core/validate_path_test.exs
@@ -140,9 +140,9 @@ defmodule Xgit.Core.ValidatePathTest do
 
     test "Windows variations on .git (applies to all platforms)" do
       for name <- @windows_git_names do
-        assert {:error, _reason} = check_path(name)
-        assert {:error, _reason} = check_path(name, windows?: true)
-        assert {:error, _reason} = check_path(name, macosx?: true)
+        assert {:error, :invalid_name} = check_path(name)
+        assert {:error, :invalid_name} = check_path(name, windows?: true)
+        assert {:error, :invalid_name} = check_path(name, macosx?: true)
       end
 
       for name <- @almost_windows_git_names do
@@ -155,7 +155,7 @@ defmodule Xgit.Core.ValidatePathTest do
     test "variations on .git on Mac" do
       for name <- @mac_hfs_git_names do
         assert :ok = check_path(:binary.bin_to_list(name))
-        assert {:error, _reason} = check_path(:binary.bin_to_list(name), macosx?: true)
+        assert {:error, :reserved_name} = check_path(:binary.bin_to_list(name), macosx?: true)
       end
 
       for name <- @almost_mac_hfs_git_names do
@@ -168,21 +168,21 @@ defmodule Xgit.Core.ValidatePathTest do
       for char <- @invalid_windows_chars do
         assert :ok = check_path([char])
         assert :ok = check_path([?a, char, ?b])
-        assert {:error, _} = check_path([char], windows?: true)
-        assert {:error, _} = check_path([?a, char, ?b], windows?: true)
+        assert {:error, :invalid_name_on_windows} = check_path([char], windows?: true)
+        assert {:error, :invalid_name_on_windows} = check_path([?a, char, ?b], windows?: true)
       end
 
       for char <- 1..31 do
         assert :ok = check_path([char])
         assert :ok = check_path([?a, char, ?b])
-        assert {:error, _} = check_path([char], windows?: true)
-        assert {:error, _} = check_path([?a, char, ?b], windows?: true)
+        assert {:error, :invalid_name_on_windows} = check_path([char], windows?: true)
+        assert {:error, :invalid_name_on_windows} = check_path([?a, char, ?b], windows?: true)
       end
     end
 
     test "git special names" do
       for name <- @git_special_names do
-        assert {:error, _} = check_path(name)
+        assert {:error, :reserved_name} = check_path(name)
       end
 
       for name <- @almost_git_special_names do
@@ -191,31 +191,31 @@ defmodule Xgit.Core.ValidatePathTest do
     end
 
     test "badly-formed UTF8 on Mac" do
-      assert {:error, _} = check_path([?a, ?b, 0xE2, 0x80], macosx?: true)
-      assert {:error, _} = check_path([?a, ?b, 0xEF, 0x80], macosx?: true)
+      assert {:error, :invalid_utf8_sequence} = check_path([?a, ?b, 0xE2, 0x80], macosx?: true)
+      assert {:error, :invalid_utf8_sequence} = check_path([?a, ?b, 0xEF, 0x80], macosx?: true)
       assert :ok = check_path([?a, ?b, 0xE2, 0x80, 0xAE], macosx?: true)
 
       bad_name = '.git' ++ [0xEF]
       assert :ok = check_path(bad_name)
-      assert {:error, _} = check_path(bad_name, macosx?: true)
+      assert {:error, :invalid_utf8_sequence} = check_path(bad_name, macosx?: true)
 
       bad_name = '.git' ++ [0xE2, 0xAB]
       assert :ok = check_path(bad_name)
-      assert {:error, _} = check_path(bad_name, macosx?: true)
+      assert {:error, :invalid_utf8_sequence} = check_path(bad_name, macosx?: true)
     end
 
     test "Windows name ending with ." do
       assert :ok = check_path('abc.')
       assert :ok = check_path('abc ')
 
-      assert {:error, "invalid name ends with '.'"} = check_path('abc.', windows?: true)
-      assert {:error, "invalid name ends with ' '"} = check_path('abc ', windows?: true)
+      assert {:error, :invalid_name_on_windows} = check_path('abc.', windows?: true)
+      assert {:error, :invalid_name_on_windows} = check_path('abc ', windows?: true)
     end
 
     test "Windows device names" do
       for name <- @windows_device_names do
         assert :ok = check_path(name)
-        assert {:error, _} = check_path(name, windows?: true)
+        assert {:error, :windows_device_name} = check_path(name, windows?: true)
       end
 
       for name <- @almost_windows_device_names do
@@ -227,7 +227,7 @@ defmodule Xgit.Core.ValidatePathTest do
 
   describe "check_path_segment/2" do
     test "basic case: no platform checks" do
-      assert check_path_segment('') == {:error, "zero length name"}
+      assert check_path_segment('') == {:error, :empty_name}
       assert check_path_segment('a') == :ok
       assert check_path_segment('a/b') == {:error, :invalid_name}
       assert check_path_segment('/a') == {:error, :invalid_name}
@@ -236,9 +236,9 @@ defmodule Xgit.Core.ValidatePathTest do
 
     test "Windows variations on .git (applies to all platforms)" do
       for name <- @windows_git_names do
-        assert {:error, _reason} = check_path_segment(name)
-        assert {:error, _reason} = check_path_segment(name, windows?: true)
-        assert {:error, _reason} = check_path_segment(name, macosx?: true)
+        assert {:error, :invalid_name} = check_path_segment(name)
+        assert {:error, :invalid_name} = check_path_segment(name, windows?: true)
+        assert {:error, :invalid_name} = check_path_segment(name, macosx?: true)
       end
 
       for name <- @almost_windows_git_names do
@@ -250,7 +250,8 @@ defmodule Xgit.Core.ValidatePathTest do
 
     test "variations on .git on Mac" do
       for name <- @mac_hfs_git_names do
-        assert {:error, _reason} = check_path_segment(:binary.bin_to_list(name), macosx?: true)
+        assert {:error, :reserved_name} =
+                 check_path_segment(:binary.bin_to_list(name), macosx?: true)
       end
     end
 
@@ -258,21 +259,25 @@ defmodule Xgit.Core.ValidatePathTest do
       for char <- @invalid_windows_chars do
         assert :ok = check_path_segment([char])
         assert :ok = check_path_segment([?a, char, ?b])
-        assert {:error, _} = check_path_segment([char], windows?: true)
-        assert {:error, _} = check_path_segment([?a, char, ?b], windows?: true)
+        assert {:error, :invalid_name_on_windows} = check_path_segment([char], windows?: true)
+
+        assert {:error, :invalid_name_on_windows} =
+                 check_path_segment([?a, char, ?b], windows?: true)
       end
 
       for char <- 1..31 do
         assert :ok = check_path_segment([char])
         assert :ok = check_path_segment([?a, char, ?b])
-        assert {:error, _} = check_path_segment([char], windows?: true)
-        assert {:error, _} = check_path_segment([?a, char, ?b], windows?: true)
+        assert {:error, :invalid_name_on_windows} = check_path_segment([char], windows?: true)
+
+        assert {:error, :invalid_name_on_windows} =
+                 check_path_segment([?a, char, ?b], windows?: true)
       end
     end
 
     test "git special names" do
       for name <- @git_special_names do
-        assert {:error, _} = check_path_segment(name)
+        assert {:error, :reserved_name} = check_path_segment(name)
       end
 
       for name <- @almost_git_special_names do
@@ -281,31 +286,35 @@ defmodule Xgit.Core.ValidatePathTest do
     end
 
     test "badly-formed UTF8 on Mac" do
-      assert {:error, _} = check_path_segment([?a, ?b, 0xE2, 0x80], macosx?: true)
-      assert {:error, _} = check_path_segment([?a, ?b, 0xEF, 0x80], macosx?: true)
+      assert {:error, :invalid_utf8_sequence} =
+               check_path_segment([?a, ?b, 0xE2, 0x80], macosx?: true)
+
+      assert {:error, :invalid_utf8_sequence} =
+               check_path_segment([?a, ?b, 0xEF, 0x80], macosx?: true)
+
       assert :ok = check_path_segment([?a, ?b, 0xE2, 0x80, 0xAE], macosx?: true)
 
       bad_name = '.git' ++ [0xEF]
       assert :ok = check_path_segment(bad_name)
-      assert {:error, _} = check_path_segment(bad_name, macosx?: true)
+      assert {:error, :invalid_utf8_sequence} = check_path_segment(bad_name, macosx?: true)
 
       bad_name = '.git' ++ [0xE2, 0xAB]
       assert :ok = check_path_segment(bad_name)
-      assert {:error, _} = check_path_segment(bad_name, macosx?: true)
+      assert {:error, :invalid_utf8_sequence} = check_path_segment(bad_name, macosx?: true)
     end
 
     test "Windows name ending with . or space" do
       assert :ok = check_path_segment('abc.')
       assert :ok = check_path_segment('abc ')
 
-      assert {:error, "invalid name ends with '.'"} = check_path_segment('abc.', windows?: true)
-      assert {:error, "invalid name ends with ' '"} = check_path_segment('abc ', windows?: true)
+      assert {:error, :invalid_name_on_windows} = check_path_segment('abc.', windows?: true)
+      assert {:error, :invalid_name_on_windows} = check_path_segment('abc ', windows?: true)
     end
 
     test "Windows device names" do
       for name <- @windows_device_names do
         assert :ok = check_path_segment(name)
-        assert {:error, _} = check_path_segment(name, windows?: true)
+        assert {:error, :windows_device_name} = check_path_segment(name, windows?: true)
       end
 
       for name <- @almost_windows_device_names do
@@ -319,7 +328,7 @@ defmodule Xgit.Core.ValidatePathTest do
     end
 
     test "rejects empty segment" do
-      assert check_path_segment([]) == {:error, "zero length name"}
+      assert check_path_segment([]) == {:error, :empty_name}
     end
 
     test "jgit bug 477090" do

--- a/test/xgit/core/validate_path_test.exs
+++ b/test/xgit/core/validate_path_test.exs
@@ -130,7 +130,7 @@ defmodule Xgit.Core.ValidatePathTest do
       assert check_path('a/b') == :ok
       assert check_path('a//b') == {:error, "duplicate '/' characters in path"}
       assert check_path('/a') == {:error, "absolute path"}
-      assert check_path('a\0b') == {:error, "name contains byte 0x00"}
+      assert check_path('a\0b') == {:error, :invalid_name}
       assert check_path('ab/cd/ef') == :ok
 
       assert check_path('ab/cd//ef') == {:error, "duplicate '/' characters in path"}
@@ -229,9 +229,9 @@ defmodule Xgit.Core.ValidatePathTest do
     test "basic case: no platform checks" do
       assert check_path_segment('') == {:error, "zero length name"}
       assert check_path_segment('a') == :ok
-      assert check_path_segment('a/b') == {:error, "name contains byte '/'"}
-      assert check_path_segment('/a') == {:error, "name contains byte '/'"}
-      assert check_path_segment('a\0b') == {:error, "name contains byte 0x00"}
+      assert check_path_segment('a/b') == {:error, :invalid_name}
+      assert check_path_segment('/a') == {:error, :invalid_name}
+      assert check_path_segment('a\0b') == {:error, :invalid_name}
     end
 
     test "Windows variations on .git (applies to all platforms)" do
@@ -315,7 +315,7 @@ defmodule Xgit.Core.ValidatePathTest do
     end
 
     test "rejects path with slash" do
-      assert check_path_segment('a/b') == {:error, "name contains byte '/'"}
+      assert check_path_segment('a/b') == {:error, :invalid_name}
     end
 
     test "rejects empty segment" do

--- a/test/xgit/plumbing/hash_object_test.exs
+++ b/test/xgit/plumbing/hash_object_test.exs
@@ -135,7 +135,7 @@ defmodule Xgit.Plumbing.HashObjectTest do
       committer A. U. Thor <author@localhost> 1 +0000
       """
 
-      assert {:error, "no tree header"} = HashObject.run(content, type: :commit)
+      assert {:error, :no_tree_header} = HashObject.run(content, type: :commit)
     end
 
     test "error: content nil" do

--- a/test/xgit/repository/on_disk/create_test.exs
+++ b/test/xgit/repository/on_disk/create_test.exs
@@ -19,9 +19,7 @@ defmodule Xgit.Repository.OnDisk.CreateTest do
 
     test "error: work dir exists already", %{xgit: xgit} do
       File.mkdir_p!(xgit)
-
-      assert {:error, "work_dir must be a directory that doesn't already exist"} =
-               OnDisk.create(xgit)
+      assert {:error, :work_dir_must_not_exist} = OnDisk.create(xgit)
     end
   end
 end


### PR DESCRIPTION
## Changes in This Pull Request
I decided that atoms were easier to match than strings. And the response pattern was more in keeping with Elixir traditions.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] There is test coverage for all changes.
- [ ] ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- [ ] ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- [ ] ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
