### PR TITLE
Bring over Xgit.Util.NB module from old jgit port.

### DIFF
--- a/lib/xgit/util/nb.ex
+++ b/lib/xgit/util/nb.ex
@@ -1,0 +1,96 @@
+# Copyright (C) 2008, 2015 Shawn O. Pearce <spearce@spearce.org>
+# and other copyright owners as documented in the project's IP log.
+#
+# Elixir adaptation from jgit file:
+# org.eclipse.jgit/src/org/eclipse/jgit/util/NB.java
+#
+# Copyright (C) 2019, Eric Scouten <eric+xgit@scouten.com>
+#
+# This program and the accompanying materials are made available
+# under the terms of the Eclipse Distribution License v1.0 which
+# accompanies this distribution, is reproduced below, and is
+# available at http://www.eclipse.org/org/documents/edl-v10.php
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or
+# without modification, are permitted provided that the following
+# conditions are met:
+#
+# - Redistributions of source code must retain the above copyright
+#   notice, this list of conditions and the following disclaimer.
+#
+# - Redistributions in binary form must reproduce the above
+#   copyright notice, this list of conditions and the following
+#   disclaimer in the documentation and/or other materials provided
+#   with the distribution.
+#
+# - Neither the name of the Eclipse Foundation, Inc. nor the
+#   names of its contributors may be used to endorse or promote
+#   products derived from this software without specific prior
+#   written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+# NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+defmodule Xgit.Util.NB do
+  @moduledoc ~S"""
+  Conversion utilities for network byte order handling.
+  """
+
+  use Bitwise
+
+  @doc ~S"""
+  Parses a sequence of 4 bytes (network byte order) as a signed integer.
+
+  Reads the first four bytes from `intbuf` and returns `{value, buf}`
+  where value is the integer value from the first four bytes at `intbuf`
+  and `buf` is the remainder of the byte array after those bytes.
+  """
+  @spec decode_int32(intbuf :: [byte]) :: {integer, [byte]}
+  def decode_int32(intbuf)
+
+  def decode_int32([b1, b2, b3, b4 | tail]) when b1 >= 128,
+    do: {b1 * 0x1000000 + b2 * 0x10000 + b3 * 0x100 + b4 - 0x100000000, tail}
+
+  def decode_int32([b1, b2, b3, b4 | tail]),
+    do: {b1 * 0x1000000 + b2 * 0x10000 + b3 * 0x100 + b4, tail}
+
+  @doc ~S"""
+  Parses a sequence of 4 bytes (network byte order) as an unsigned integer.
+
+  Reads the first four bytes from `intbuf` and returns `{value, buf}`
+  where value is the unsigned integer value from the first four bytes at `intbuf`
+  and `buf` is the remainder of the byte array after those bytes.
+  """
+  @spec decode_uint32(intbuf :: [byte]) :: {integer, [byte]}
+  def decode_uint32(intbuf)
+
+  def decode_uint32([b1, b2, b3, b4 | tail]),
+    do: {b1 * 0x1000000 + b2 * 0x10000 + b3 * 0x100 + b4, tail}
+
+  @doc ~S"""
+  Convert a 16-bit integer to a sequence of two bytes in network byte order.
+  """
+  @spec encode_int16(v :: integer) :: [byte]
+  def encode_int16(v) when is_integer(v) and v >= -32_768 and v <= 65_535,
+    do: [v >>> 8 &&& 0xFF, v &&& 0xFF]
+
+  @doc ~S"""
+  Convert a 32-bit integer to a sequence of four bytes in network byte order.
+  """
+  @spec encode_int32(v :: integer) :: [byte]
+  def encode_int32(v) when is_integer(v) and v >= -2_147_483_647 and v <= 4_294_967_296,
+    do: [v >>> 24 &&& 0xFF, v >>> 16 &&& 0xFF, v >>> 8 &&& 0xFF, v &&& 0xFF]
+end

--- a/test/xgit/util/nb_test.exs
+++ b/test/xgit/util/nb_test.exs
@@ -1,0 +1,116 @@
+# Copyright (C) 2008, 2015 Google Inc.
+# and other copyright owners as documented in the project's IP log.
+#
+# Elixir adaptation from jgit file:
+# org.eclipse.jgit.test/tst/org/eclipse/jgit/util/NBTest.java
+#
+# Copyright (C) 2019, Eric Scouten <eric+xgit@scouten.com>
+#
+# This program and the accompanying materials are made available
+# under the terms of the Eclipse Distribution License v1.0 which
+# accompanies this distribution, is reproduced below, and is
+# available at http://www.eclipse.org/org/documents/edl-v10.php
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or
+# without modification, are permitted provided that the following
+# conditions are met:
+#
+# - Redistributions of source code must retain the above copyright
+#   notice, this list of conditions and the following disclaimer.
+#
+# - Redistributions in binary form must reproduce the above
+#   copyright notice, this list of conditions and the following
+#   disclaimer in the documentation and/or other materials provided
+#   with the distribution.
+#
+# - Neither the name of the Eclipse Foundation, Inc. nor the
+#   names of its contributors may be used to endorse or promote
+#   products derived from this software without specific prior
+#   written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+# NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+defmodule Xgit.Util.NBTest do
+  use ExUnit.Case, async: true
+
+  alias Xgit.Util.NB
+
+  describe "decode_int32/1" do
+    test "simple cases" do
+      assert NB.decode_int32([0, 0, 0, 0, 0]) == {0, [0]}
+      assert NB.decode_int32([0, 0, 0, 0, 3]) == {0, [3]}
+
+      assert NB.decode_int32([0, 0, 0, 0, 3, 42]) == {0, [3, 42]}
+
+      assert NB.decode_int32([0, 0, 0, 3]) == {3, []}
+      assert NB.decode_int32([0, 0, 0, 3, 0]) == {3, [0]}
+      assert NB.decode_int32([0, 0, 0, 3, 3]) == {3, [3]}
+
+      assert NB.decode_int32([0x03, 0x10, 0xAD, 0xEF, 1]) == {0x0310ADEF, [1]}
+    end
+
+    test "negative numbers" do
+      assert NB.decode_int32([0xFF, 0xFF, 0xFF, 0xFF, 0xFE]) == {-1, [0xFE]}
+      assert NB.decode_int32([0xDE, 0xAD, 0xBE, 0xEF, 1]) == {-559_038_737, [1]}
+    end
+
+    test "rejects byte list too short" do
+      assert_raise FunctionClauseError, fn ->
+        NB.decode_int32([1, 2, 3])
+      end
+    end
+  end
+
+  describe "decode_uint32/1" do
+    test "simple cases" do
+      assert NB.decode_uint32([0, 0, 0, 0, 0]) == {0, [0]}
+      assert NB.decode_uint32([0, 0, 0, 0, 3]) == {0, [3]}
+
+      assert NB.decode_uint32([0, 0, 0, 0, 3, 42]) == {0, [3, 42]}
+
+      assert NB.decode_uint32([0, 0, 0, 3]) == {3, []}
+      assert NB.decode_uint32([0, 0, 0, 3, 0]) == {3, [0]}
+      assert NB.decode_uint32([0, 0, 0, 3, 3]) == {3, [3]}
+
+      assert NB.decode_uint32([0x03, 0x10, 0xAD, 0xEF, 1]) == {0x0310ADEF, [1]}
+
+      assert NB.decode_uint32([0xFF, 0xFF, 0xFF, 0xFF, 0xFE]) == {0xFFFFFFFF, [0xFE]}
+      assert NB.decode_uint32([0xDE, 0xAD, 0xBE, 0xEF, 1]) == {0xDEADBEEF, [1]}
+    end
+
+    test "rejects byte list too short" do
+      assert_raise FunctionClauseError, fn ->
+        NB.decode_uint32([1, 2, 3])
+      end
+    end
+  end
+
+  test "encode_int16/1" do
+    assert NB.encode_int16(0) == [0, 0]
+    assert NB.encode_int16(3) == [0, 3]
+    assert NB.encode_int16(0xDEAC) == [0xDE, 0xAC]
+    assert NB.encode_int16(-1) == [0xFF, 0xFF]
+  end
+
+  test "encode_int32/1" do
+    assert NB.encode_int32(0) == [0, 0, 0, 0]
+    assert NB.encode_int32(3) == [0, 0, 0, 3]
+    assert NB.encode_int32(0xDEAC) == [0, 0, 0xDE, 0xAC]
+    assert NB.encode_int32(0xDEAC9853) == [0xDE, 0xAC, 0x98, 0x53]
+    assert NB.encode_int32(-1) == [0xFF, 0xFF, 0xFF, 0xFF]
+  end
+end


### PR DESCRIPTION
## Changes in This Pull Request
Archived jgit port had a nice network byte-order module.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] There is test coverage for all changes.
- [x] Any code ported from jgit maintains all existing copyright and license notices.
- [x] If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.
- [ ] ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
