### PR TITLE
In-memory repository.

### DIFF
--- a/lib/xgit/repository.ex
+++ b/lib/xgit/repository.ex
@@ -16,8 +16,8 @@ defmodule Xgit.Repository do
 
   Xgit intends to allow repositories to be stored in multiple different mechanisms.
   While it includes built-in support for local on-disk repositories
-  (see `Xgit.Repository.OnDisk`), you could envision repositories stored entirely
-  in memory, or on a remote file system or database.
+  (see `Xgit.Repository.OnDisk`), and in-lib repositories (see `Xgit.Repository.InMemory`),
+  you could envision repositories stored entirely on a remote file system or database.
 
   ## Implementing a Storage Architecture
 

--- a/lib/xgit/repository/in_memory.ex
+++ b/lib/xgit/repository/in_memory.ex
@@ -1,0 +1,60 @@
+defmodule Xgit.Repository.InMemory do
+  @moduledoc ~S"""
+  Implementation of `Xgit.Repository` that stores content in memory.
+
+  _WARNING:_ This is intended for testing purposes only. As the name implies,
+  repository content is stored only in memory. When the process that implements
+  this repository terminates, the content it stores is lost.
+  """
+  use Xgit.Repository
+
+  alias Xgit.Core.ContentSource
+  alias Xgit.Core.Object
+
+  @doc ~S"""
+  Start an in-memory git repository.
+
+  Use the functions in `Xgit.Repository` to interact with this repository process.
+
+  Any options are passed through to `GenServer.start_link/3`.
+
+  ## Return Value
+
+  See `GenServer.start_link/3`.
+  """
+  @spec start_link(opts :: Keyword.t()) :: GenServer.on_start()
+  def start_link(opts \\ []), do: Repository.start_link(__MODULE__, opts, opts)
+
+  @impl true
+  def init(opts) when is_list(opts), do: {:ok, %{loose_objects: %{}}}
+
+  @impl true
+  def handle_get_object(%{loose_objects: objects} = state, object_id) do
+    # Currently only checks for loose objects.
+    # TO DO: Look for object in packs.
+    # https://github.com/elixir-git/xgit/issues/52
+
+    case Map.get(objects, object_id) do
+      %Object{} = object -> {:ok, object, state}
+      nil -> {:error, :not_found, state}
+    end
+  end
+
+  @impl true
+  def handle_put_loose_object(%{loose_objects: loose_objects} = state, %Object{id: id} = object) do
+    if Map.has_key?(loose_objects, id) do
+      {:error, :object_exists, state}
+    else
+      # Convert any pending content into a byte list.
+      # We don't bother with zlib compression here.
+      new_objects = Map.put(loose_objects, id, maybe_read_object_content(object))
+      {:ok, %{state | loose_objects: new_objects}}
+    end
+  end
+
+  defp maybe_read_object_content(%Object{content: content} = object) when is_list(content),
+    do: object
+
+  defp maybe_read_object_content(%Object{content: content} = object),
+    do: %{object | content: content |> ContentSource.stream() |> Enum.concat()}
+end

--- a/test/xgit/repository/in_memory/get_object_test.exs
+++ b/test/xgit/repository/in_memory/get_object_test.exs
@@ -1,0 +1,17 @@
+defmodule Xgit.Repository.InMemory.GetObjectTest do
+  use Xgit.GitInitTestCase, async: true
+
+  alias Xgit.Repository
+  alias Xgit.Repository.InMemory
+
+  describe "get_object/2" do
+    # Happy paths involving existing items are tested in put_loose_object_test.
+
+    test "error: no such object" do
+      assert {:ok, repo} = InMemory.start_link()
+
+      assert {:error, :not_found} =
+               Repository.get_object(repo, "5cb5d77be2d92c7368038dac67e648a69e0a654d")
+    end
+  end
+end

--- a/test/xgit/repository/in_memory/put_loose_object_test.exs
+++ b/test/xgit/repository/in_memory/put_loose_object_test.exs
@@ -1,0 +1,66 @@
+defmodule Xgit.Repository.InMemory.PutLooseObjectTest do
+  use ExUnit.Case, async: true
+
+  alias Xgit.Core.ContentSource
+  alias Xgit.Core.FileContentSource
+  alias Xgit.Core.Object
+  alias Xgit.Repository
+  alias Xgit.Repository.InMemory
+
+  describe "put_loose_object/2" do
+    # Also tests corresonding cases of get_object/2.
+    @test_content 'test content\n'
+    @test_content_id "d670460b4b4aece5915caf5c68d12f560a9fe3e4"
+
+    test "happy path: put and get back" do
+      assert {:ok, repo} = InMemory.start_link()
+
+      object = %Object{type: :blob, content: @test_content, size: 13, id: @test_content_id}
+      assert :ok = Repository.put_loose_object(repo, object)
+
+      assert {:ok, ^object} = Repository.get_object(repo, @test_content_id)
+    end
+
+    test "happy path: reads file into memory" do
+      Temp.track!()
+      path = Temp.path!()
+
+      content =
+        1..1000
+        |> Enum.map(fn _ -> "foobar" end)
+        |> Enum.join()
+
+      File.write!(path, content)
+      content_id = "b9fce9aed947fd9f5a160c18cf2983fe455f8daf"
+      # ^ lifted from running the corresponding on-disk test.
+
+      assert {:ok, repo} = InMemory.start_link()
+
+      fcs = FileContentSource.new(path)
+      object = %Object{type: :blob, content: fcs, size: ContentSource.length(fcs), id: content_id}
+      assert :ok = Repository.put_loose_object(repo, object)
+
+      content_as_binary = :binary.bin_to_list(content)
+      content_size = byte_size(content)
+
+      assert {ok,
+              %Object{
+                type: :blob,
+                content: ^content_as_binary,
+                size: ^content_size,
+                id: ^content_id
+              }} = Repository.get_object(repo, content_id)
+    end
+
+    test "error: object exists already" do
+      assert {:ok, repo} = InMemory.start_link()
+
+      object = %Object{type: :blob, content: @test_content, size: 13, id: @test_content_id}
+      assert :ok = Repository.put_loose_object(repo, object)
+
+      assert {:error, :object_exists} = Repository.put_loose_object(repo, object)
+
+      assert {:ok, ^object} = Repository.get_object(repo, @test_content_id)
+    end
+  end
+end


### PR DESCRIPTION
## Changes in This Pull Request
Adds `Xgit.Repository.InMemory` which helps prove the point that the `Repository` interface is about storage abstraction.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] There is test coverage for all changes.
- [ ] ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- [ ] ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- [ ] ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
