### PR TITLE
Factor out a generic "not valid" GenServer for use in testing.

### DIFF
--- a/test/support/not_valid.ex
+++ b/test/support/not_valid.ex
@@ -1,0 +1,13 @@
+defmodule NotValid do
+  @moduledoc false
+  # This module can be used to test the invalid case for Repository.valid?
+  # and similar. It will not respond properly to such messages.
+
+  use GenServer
+
+  @impl true
+  def init(nil), do: {:ok, nil}
+
+  @impl true
+  def handle_call(_request, _from, _state), do: {:reply, :whatever, nil}
+end

--- a/test/xgit/plumbing/cat_file_test.exs
+++ b/test/xgit/plumbing/cat_file_test.exs
@@ -5,16 +5,6 @@ defmodule Xgit.Plumbing.CatFileTest do
   alias Xgit.Plumbing.HashObject
   alias Xgit.Repository.OnDisk
 
-  defmodule NotRepo do
-    use GenServer
-
-    @impl true
-    def init(_init_arg), do: {:ok, nil}
-
-    @impl true
-    def handle_call(_request, _from, _state), do: {:reply, :whatever, nil}
-  end
-
   describe "run/2" do
     test "happy path: can read from command-line git (small file)", %{ref: ref} do
       Temp.track!()
@@ -74,7 +64,7 @@ defmodule Xgit.Plumbing.CatFileTest do
     end
 
     test "error: repository invalid (PID, but not repo)" do
-      {:ok, not_repo} = GenServer.start_link(NotRepo, [])
+      {:ok, not_repo} = GenServer.start_link(NotValid, nil)
 
       assert {:error, :invalid_repository} =
                CatFile.run(not_repo, "18a4a651653d7caebd3af9c05b0dc7ffa2cd0ae0")


### PR DESCRIPTION
Currently only used in CatFileTest, but will be used elsewhere soon.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [ ] ~All applicable changes have been documented.~ _n/a_
- [ ] ~There is test coverage for all changes.~ _n/a_
- [ ] ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- [ ] ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- [ ] ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
