### PR TITLE
Rename Xgit.Core.IndexFile to Xgit.Core.DirCache.

### DIFF
--- a/test/xgit/core/dir_cache_test.exs
+++ b/test/xgit/core/dir_cache_test.exs
@@ -1,7 +1,7 @@
-defmodule Xgit.Core.IndexFileTest do
+defmodule Xgit.Core.DirCacheTest do
   use Xgit.GitInitTestCase, async: true
 
-  alias Xgit.Core.IndexFile
+  alias Xgit.Core.DirCache
 
   describe "from_iodevice/1" do
     test "happy path: can read from command-line git (empty index)", %{ref: ref} do
@@ -34,9 +34,9 @@ defmodule Xgit.Core.IndexFileTest do
                [ref, ".git", "index"]
                |> Path.join()
                |> File.open!()
-               |> IndexFile.from_iodevice()
+               |> DirCache.from_iodevice()
 
-      assert index_file = %IndexFile{
+      assert index_file = %DirCache{
                entries: [],
                entry_count: 0,
                version: 2
@@ -76,11 +76,11 @@ defmodule Xgit.Core.IndexFileTest do
                [ref, ".git", "index"]
                |> Path.join()
                |> File.open!()
-               |> IndexFile.from_iodevice()
+               |> DirCache.from_iodevice()
 
-      assert index_file = %IndexFile{
+      assert index_file = %DirCache{
                entries: [
-                 %IndexFile.Entry{
+                 %DirCache.Entry{
                    assume_valid?: false,
                    ctime: 0,
                    ctime_ns: 0,
@@ -99,7 +99,7 @@ defmodule Xgit.Core.IndexFileTest do
                    stage: 0,
                    uid: 0
                  },
-                 %IndexFile.Entry{
+                 %DirCache.Entry{
                    assume_valid?: false,
                    ctime: 0,
                    ctime_ns: 0,
@@ -215,7 +215,7 @@ defmodule Xgit.Core.IndexFileTest do
     iodata
     |> IO.iodata_to_binary()
     |> stringio_open!()
-    |> IndexFile.from_iodevice()
+    |> DirCache.from_iodevice()
   end
 
   defp stringio_open!(s) do


### PR DESCRIPTION
This module represents the abstract concept of a directory cache.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] There is test coverage for all changes.
- [ ] ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- [ ] ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- [ ] ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
