### PR TITLE
Add DirCache.Entry.compare/2 which can be used to enforce sort order rules.

### DIFF
--- a/lib/xgit/core/dir_cache.ex
+++ b/lib/xgit/core/dir_cache.ex
@@ -129,5 +129,40 @@ defmodule Xgit.Core.DirCache do
       skip_worktree?: false,
       intent_to_add?: false
     ]
+
+    @doc ~S"""
+    Compare two entries according to git dir cache entry sort ordering rules.
+
+    For this purpose, only the following fields are considered (in this priority order):
+
+    * `:name`
+    * `:mode`
+    * `:stage`
+
+    ## Return Value
+
+    * `:lt` if `entry1` sorts before `entry2`.
+    * `:eq` if they are the same.
+    * `:gt` if `entry1` sorts after `entry2`.
+    """
+    @spec compare(entry1 :: t | nil, entry2 :: t) :: :lt | :eq | :gt
+    def compare(entry1, entry2)
+
+    def compare(nil, _entry2), do: :lt
+
+    def compare(
+          %{name: name1, mode: mode1, stage: stage1} = _entry1,
+          %{name: name2, mode: mode2, stage: stage2} = _entry2
+        ) do
+      cond do
+        name1 < name2 -> :lt
+        name2 < name1 -> :gt
+        mode1 < mode2 -> :lt
+        mode2 < mode1 -> :gt
+        stage1 < stage2 -> :lt
+        stage2 < stage1 -> :gt
+        true -> :eq
+      end
+    end
   end
 end

--- a/test/xgit/core/dir_cache/entry_test.exs
+++ b/test/xgit/core/dir_cache/entry_test.exs
@@ -1,0 +1,53 @@
+defmodule Xgit.Core.DirCache.EntryTest do
+  use ExUnit.Case, async: true
+
+  alias Xgit.Core.DirCache.Entry
+
+  @valid %Entry{
+    name: 'hello.txt',
+    stage: 0,
+    object_id: "7919e8900c3af541535472aebd56d44222b7b3a3",
+    mode: 0o100644,
+    size: 42,
+    ctime: 1_565_612_933,
+    ctime_ns: 0,
+    mtime: 1_565_612_941,
+    mtime_ns: 0,
+    dev: 0,
+    ino: 0,
+    uid: 0,
+    gid: 0,
+    assume_valid?: true,
+    extended?: false,
+    skip_worktree?: true,
+    intent_to_add?: false
+  }
+
+  describe "compare/2" do
+    test "special case: nil sorts first" do
+      assert Entry.compare(nil, @valid) == :lt
+    end
+
+    test "equality" do
+      assert Entry.compare(@valid, @valid) == :eq
+    end
+
+    @name_gt Map.put(@valid, :name, 'later.txt')
+    test "comparison based on name" do
+      assert Entry.compare(@valid, @name_gt) == :lt
+      assert Entry.compare(@name_gt, @valid) == :gt
+    end
+
+    @mode_gt Map.put(@valid, :mode, 0o100755)
+    test "comparison based on mode" do
+      assert Entry.compare(@valid, @mode_gt) == :lt
+      assert Entry.compare(@mode_gt, @valid) == :gt
+    end
+
+    @stage_gt Map.put(@valid, :stage, 2)
+    test "comparison based on stage" do
+      assert Entry.compare(@valid, @stage_gt) == :lt
+      assert Entry.compare(@stage_gt, @valid) == :gt
+    end
+  end
+end


### PR DESCRIPTION
## Changes in This Pull Request
Will be used in an upcoming PR to ensure dir cache is properly sorted.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] There is test coverage for all changes.
- [ ] ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- [ ] ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- [ ] ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
