### PR TITLE
Clarify distinction between the two object validity checks.

### DIFF
--- a/lib/xgit/core/object.ex
+++ b/lib/xgit/core/object.ex
@@ -33,6 +33,10 @@ defmodule Xgit.Core.Object do
 
   @doc ~S"""
   Return `true` if the struct describes a valid object.
+
+  _IMPORTANT:_ This validation _only_ verifies that the struct itself is valid.
+  It does not inspect the content of the object. That check can be performed by
+  `Xgit.Core.ValidateObject.check/2`.
   """
   @spec valid?(object :: any) :: boolean
   def valid?(object)

--- a/lib/xgit/core/validate_object.ex
+++ b/lib/xgit/core/validate_object.ex
@@ -94,6 +94,10 @@ defmodule Xgit.Core.ValidateObject do
   @doc ~S"""
   Verify that a proposed object is valid.
 
+  This function performs a detailed check on the _content_ of the object.
+  For a simpler verification that the `Xgit.Core.Object` struct is _itself_
+  valid, see `Xgit.Core.Object.valid?/1`.
+
   ## Options
 
   By default, this function will only enforce Posix file name restrictions.


### PR DESCRIPTION
## Changes in This Pull Request
The distinction between `Object.valid?/1` and `ValidateObject.check/2` is potentially unclear. Hopefully new comments make it more clear.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [ ] ~There is test coverage for all changes.~ _n/a_
- [ ] ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- [ ] ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- [ ] ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
