### PR TITLE
Bring over Xgit.Util.FileSnapshot from old jgit port.

### DIFF
--- a/lib/xgit.ex
+++ b/lib/xgit.ex
@@ -9,7 +9,13 @@ defmodule Xgit do
   """
   @impl true
   def start(_type, _args) do
-    children = []
+    children = [
+      {ConCache,
+       name: :xgit_file_snapshot,
+       ttl_check_interval: :timer.seconds(1),
+       global_ttl: :timer.seconds(5)}
+    ]
+
     Supervisor.start_link(children, strategy: :one_for_one)
   end
 end

--- a/lib/xgit/util/file_snapshot.ex
+++ b/lib/xgit/util/file_snapshot.ex
@@ -156,8 +156,14 @@ defmodule Xgit.Util.FileSnapshot do
       snapshot
     end
   ```
+
+  ## Return Value
+
+  `:ok`
   """
-  @spec set_clean(snapshot :: t, other :: t) :: t
+  @spec set_clean(snapshot :: t, other :: t) :: :ok
+  def set_clean(sanpshot, other)
+  
   def set_clean(
         %__MODULE__{last_modified: last_modified, ref: ref},
         %__MODULE__{ref: other_ref}
@@ -167,6 +173,8 @@ defmodule Xgit.Util.FileSnapshot do
     if not_racy_clean?(last_modified, other_last_read),
       do: ConCache.delete(:xgit_file_snapshot, ref),
       else: record_time_for_ref(ref, not_racy_clean?(last_modified, other_last_read))
+
+    :ok
   end
 
   defp modified_impl?(file_last_modified, last_modified, ref) do

--- a/lib/xgit/util/file_snapshot.ex
+++ b/lib/xgit/util/file_snapshot.ex
@@ -1,0 +1,228 @@
+# Copyright (C) 2010, Google Inc.
+# and other copyright owners as documented in the project's IP log.
+#
+# Elixir adaptation from jgit file:
+# org.eclipse.jgit/src/org/eclipse/jgit/internal/storage/file/FileSnapshot.java
+#
+# Copyright (C) 2019, Eric Scouten <eric+xgit@scouten.com>
+#
+# This program and the accompanying materials are made available
+# under the terms of the Eclipse Distribution License v1.0 which
+# accompanies this distribution, is reproduced below, and is
+# available at http://www.eclipse.org/org/documents/edl-v10.php
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or
+# without modification, are permitted provided that the following
+# conditions are met:
+#
+# - Redistributions of source code must retain the above copyright
+#   notice, this list of conditions and the following disclaimer.
+#
+# - Redistributions in binary form must reproduce the above
+#   copyright notice, this list of conditions and the following
+#   disclaimer in the documentation and/or other materials provided
+#   with the distribution.
+#
+# - Neither the name of the Eclipse Foundation, Inc. nor the
+#   names of its contributors may be used to endorse or promote
+#   products derived from this software without specific prior
+#   written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+# NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+defmodule Xgit.Util.FileSnapshot do
+  @moduledoc ~S"""
+  Caches when a file was last read, making it possible to detect future edits.
+
+  This object tracks the last modified time of a file. Later during an
+  invocation of `modified?/2` the object will return `true` if the file may have
+  been modified and should be re-read from disk.
+
+  A snapshot does not "live update" when the underlying filesystem changes.
+  Callers must poll for updates by periodically invoking `modified?/2`.
+
+  To work around the "racy git" problem (where a file may be modified multiple
+  times within the granularity of the filesystem modification clock) this class
+  may return `true` from `modified?/2` if the last modification time of the
+  file is less than 3 seconds ago.
+  """
+
+  @typedoc ~S"""
+  Cache for when a file was last saved.
+
+  ## Struct Members
+
+  * `last_modified`: Last observed modification time of the path.
+  * `ref`: Reference into a cache for when this file was last read.
+  """
+  @type t :: %__MODULE__{last_modified: integer | :missing | :dirty, ref: reference | nil}
+
+  @enforce_keys [:last_modified, :ref]
+  defstruct [:last_modified, :ref]
+
+  @doc ~S"""
+  An `Xgit.Util.FileSnapshot` that is considered to always be modified.
+
+  This instance is useful for application code that wants to lazily read a
+  file, but only after `modified?/2` gets invoked. This snapshot instance
+  contains only invalid status information.
+  """
+  @spec dirty() :: t
+  def dirty, do: %__MODULE__{last_modified: :dirty, ref: nil}
+
+  @doc ~S"""
+  An `Xgit.Util.FileSnapshot` that is clean if the file does not exist.
+
+  This instance is useful if the application wants to consider a missing
+  file to be clean. `modified?/2` will return `false` if the file path
+  does not exist.
+  """
+  @spec missing_file :: t
+  def missing_file, do: %__MODULE__{last_modified: :missing, ref: nil}
+
+  @doc ~S"""
+  Record a snapshot for a specific file path.
+
+  This function should be invoked before the file is accessed.
+  """
+  @spec save(path :: Path.t()) :: t
+  def save(path) when is_binary(path) do
+    last_modified = last_modified_time(path)
+
+    ref = make_ref()
+    record_time_for_ref(ref)
+
+    %__MODULE__{last_modified: last_modified, ref: ref}
+  end
+
+  @doc ~S"""
+  Return `true` if the path may have been modified since the snapshot was saved.
+  """
+  @spec modified?(snapshot :: t, path :: Path.t()) :: boolean
+  def modified?(%__MODULE__{last_modified: last_modified, ref: ref}, path)
+      when is_binary(path) and is_integer(last_modified) and is_reference(ref) do
+    curr_last_modified = last_modified_time(path)
+    modified_impl?(curr_last_modified, last_modified, ref)
+  end
+
+  def modified?(%__MODULE__{last_modified: :dirty}, _path), do: true
+  def modified?(%__MODULE__{last_modified: :missing}, path), do: File.exists?(path)
+
+  # Dialyzer appears unaware of the effect of `time: :posix` on `File.Stat!/1`
+  # and produces warnings that it can not succeed.
+  # @dialyzer {:nowarn_function, last_modified_time: 1}
+  defp last_modified_time(path) when is_binary(path) do
+    path
+    |> File.stat!(time: :posix)
+    |> extract_last_modified_time()
+  end
+
+  # @dialyzer {:nowarn_function, extract_last_modified_time: 1}
+  defp extract_last_modified_time(%{mtime: lmt}) when is_integer(lmt), do: lmt
+
+  @doc ~S"""
+  Update this snapshot when the content hasn't changed.
+
+  If the caller gets `true` from `modified?/2`, re-reads the content, discovers
+  the content is identical, it can use to make a future call to `modified?/2`
+  return `false`.
+
+  A typical invocation looks something like this:
+
+  ```
+  new_snapshot =
+    if FileSnapshot.modified?(snapshot, path) do
+      other = FileSnapshot.save(path)
+      if old_content_matches_new_content? and snapshot.last_modified == other.last_modified do
+        FileSnapshot.set_clean(snapshot, other)
+      else
+        snapshot
+      end
+    else
+      snapshot
+    end
+  ```
+  """
+  @spec set_clean(snapshot :: t, other :: t) :: t
+  def set_clean(
+        %__MODULE__{last_modified: last_modified, ref: ref},
+        %__MODULE__{ref: other_ref}
+      ) do
+    other_last_read = ConCache.get(:xgit_file_snapshot, other_ref)
+
+    if not_racy_clean?(last_modified, other_last_read),
+      do: ConCache.delete(:xgit_file_snapshot, ref),
+      else: record_time_for_ref(ref, not_racy_clean?(last_modified, other_last_read))
+  end
+
+  defp modified_impl?(file_last_modified, last_modified, ref) do
+    last_read_time = ConCache.get(:xgit_file_snapshot, ref)
+
+    if last_modified == file_last_modified,
+      do: modified_impl_race?(file_last_modified, last_read_time),
+      else: true
+  end
+
+  # There's a potential race condition in which the file was modified at roughly
+  # the same time as the last time we read the modification time. If these two
+  # events are too close together, we have to assume the file is modified.
+
+  defp modified_impl_race?(_file_last_modified, x) when x == false or x == nil do
+    # We have already determined the last read was far enough
+    # after the last modification that any new modifications
+    # are certain to change the last modified time.
+    false
+  end
+
+  defp modified_impl_race?(file_last_modified, last_read_time) do
+    if not_racy_clean?(file_last_modified, last_read_time) do
+      # Our last read should have marked cannotBeRacilyClean,
+      # but this thread may not have seen the change. The read
+      # of the volatile field lastRead should have fixed that.
+      false
+    else
+      # We last read this path too close to its last observed
+      # modification time. We may have missed a modification.
+      # Scan again, to ensure we still see the same state.
+      true
+    end
+  end
+
+  defp not_racy_clean?(last_modified_time, last_read_time) do
+    last_read_time - last_modified_time >= 3
+    # The last modified time granularity of FAT filesystems is 2 seconds.
+    # Using 3 seconds here provides a reasonably high assurance that
+    # a modification was not missed.
+  end
+
+  defp record_time_for_ref(ref, time \\ :os.system_time(:second)) when is_reference(ref),
+    do: ConCache.put(:xgit_file_snapshot, ref, time)
+
+  defimpl String.Chars do
+    alias Xgit.Util.FileSnapshot
+
+    @impl true
+    def to_string(%FileSnapshot{last_modified: :dirty}), do: "DIRTY"
+
+    def to_string(%FileSnapshot{last_modified: :missing}), do: "MISSING_FILE"
+
+    def to_string(%FileSnapshot{last_modified: last_modified, ref: ref}) do
+      last_read_time = ConCache.get(:xgit_file_snapshot, ref)
+      "FileSnapshot[modified: #{last_modified}, read: #{last_read_time}]"
+    end
+  end
+end

--- a/lib/xgit/util/file_snapshot.ex
+++ b/lib/xgit/util/file_snapshot.ex
@@ -122,16 +122,12 @@ defmodule Xgit.Util.FileSnapshot do
   def modified?(%__MODULE__{last_modified: :dirty}, _path), do: true
   def modified?(%__MODULE__{last_modified: :missing}, path), do: File.exists?(path)
 
-  # Dialyzer appears unaware of the effect of `time: :posix` on `File.Stat!/1`
-  # and produces warnings that it can not succeed.
-  # @dialyzer {:nowarn_function, last_modified_time: 1}
   defp last_modified_time(path) when is_binary(path) do
     path
     |> File.stat!(time: :posix)
     |> extract_last_modified_time()
   end
 
-  # @dialyzer {:nowarn_function, extract_last_modified_time: 1}
   defp extract_last_modified_time(%{mtime: lmt}) when is_integer(lmt), do: lmt
 
   @doc ~S"""
@@ -163,7 +159,7 @@ defmodule Xgit.Util.FileSnapshot do
   """
   @spec set_clean(snapshot :: t, other :: t) :: :ok
   def set_clean(sanpshot, other)
-  
+
   def set_clean(
         %__MODULE__{last_modified: last_modified, ref: ref},
         %__MODULE__{ref: other_ref}

--- a/mix.exs
+++ b/mix.exs
@@ -22,6 +22,7 @@ defmodule Xgit.MixProject do
 
   defp deps do
     [
+      {:con_cache, "~> 0.13"},
       {:credo, "~> 1.1", only: [:dev, :test]},
       {:dialyxir, "~> 1.0.0-rc.6", only: :dev, runtime: false},
       {:excoveralls, "~> 0.10", only: :test},

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,7 @@
 %{
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], []},
   "certifi": {:hex, :certifi, "2.5.1", "867ce347f7c7d78563450a18a6a28a8090331e77fa02380b4a21962a65d36ee5", [:rebar3], [{:parse_trans, "~>3.3", [hex: :parse_trans, optional: false]}]},
+  "con_cache": {:hex, :con_cache, "0.13.1", "047e097ab2a8c6876e12d0c29e29a86d487b592df97b98e3e2abedad574e215d", [:mix], []},
   "credo": {:hex, :credo, "1.1.0", "e0c07b2fd7e2109495f582430a1bc96b2c71b7d94c59dfad120529f65f19872f", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, optional: false]}, {:jason, "~> 1.0", [hex: :jason, optional: false]}]},
   "dialyxir": {:hex, :dialyxir, "1.0.0-rc.6", "78e97d9c0ff1b5521dd68041193891aebebce52fc3b93463c0a6806874557d7d", [:mix], [{:erlex, "~> 0.2.1", [hex: :erlex, optional: false]}]},
   "earmark": {:hex, :earmark, "1.3.2", "b840562ea3d67795ffbb5bd88940b1bed0ed9fa32834915125ea7d02e35888a5", [:mix], []},

--- a/test/xgit/util/file_snapshot_test.exs
+++ b/test/xgit/util/file_snapshot_test.exs
@@ -1,0 +1,161 @@
+# Copyright (C) 2010, Robin Rosenberg
+# and other copyright owners as documented in the project's IP log.
+#
+# Elixir adaptation from jgit file:
+# org.eclipse.jgit.test/tst/org/eclipse/jgit/internal/storage/file/FileSnapshotTest.java
+#
+# Copyright (C) 2019, Eric Scouten <eric+xgit@scouten.com>
+#
+# This program and the accompanying materials are made available
+# under the terms of the Eclipse Distribution License v1.0 which
+# accompanies this distribution, is reproduced below, and is
+# available at http://www.eclipse.org/org/documents/edl-v10.php
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or
+# without modification, are permitted provided that the following
+# conditions are met:
+#
+# - Redistributions of source code must retain the above copyright
+#   notice, this list of conditions and the following disclaimer.
+#
+# - Redistributions in binary form must reproduce the above
+#   copyright notice, this list of conditions and the following
+#   disclaimer in the documentation and/or other materials provided
+#   with the distribution.
+#
+# - Neither the name of the Eclipse Foundation, Inc. nor the
+#   names of its contributors may be used to endorse or promote
+#   products derived from this software without specific prior
+#   written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+# NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+defmodule Xgit.Util.FileSnapshotTest do
+  use ExUnit.Case, async: true
+
+  alias Xgit.Util.FileSnapshot
+
+  setup do
+    Temp.track!()
+    temp_file_path = Temp.mkdir!(prefix: "tmp_")
+    {:ok, trash: temp_file_path}
+  end
+
+  defp wait_next_sec(f) when is_binary(f) do
+    %{mtime: initial_last_modified} = File.stat!(f, time: :posix)
+    wait_next_sec(f, initial_last_modified)
+  end
+
+  defp wait_next_sec(f, initial_last_modified) do
+    time_now = :os.system_time(:second)
+
+    if time_now <= initial_last_modified do
+      Process.sleep(100)
+      wait_next_sec(f, initial_last_modified)
+    end
+  end
+
+  test "missing_file/0", %{trash: trash} do
+    missing = FileSnapshot.missing_file()
+    path = Temp.path!()
+
+    refute FileSnapshot.modified?(missing, path)
+
+    f1 = create_file!(trash, "missing")
+    assert FileSnapshot.modified?(missing, f1)
+
+    assert to_string(missing) == "MISSING_FILE"
+  end
+
+  test "actually is modified (trivial case)", %{trash: trash} do
+    f1 = create_file!(trash, "simple")
+    wait_next_sec(f1)
+
+    save = FileSnapshot.save(f1)
+    append!(f1, 'x')
+
+    wait_next_sec(f1)
+
+    assert FileSnapshot.modified?(save, f1) == true
+
+    assert String.starts_with?(to_string(save), "FileSnapshot")
+  end
+
+  test "new file without significant wait", %{trash: trash} do
+    f1 = create_file!(trash, "newfile")
+    wait_next_sec(f1)
+
+    save = FileSnapshot.save(f1)
+
+    Process.sleep(1500)
+    assert FileSnapshot.modified?(save, f1) == true
+  end
+
+  test "new file without wait", %{trash: trash} do
+    # Same as above but do not wait at all.
+
+    f1 = create_file!(trash, "newfile")
+    wait_next_sec(f1)
+
+    save = FileSnapshot.save(f1)
+    assert FileSnapshot.modified?(save, f1) == true
+  end
+
+  test "dirty snapshot is always dirty", %{trash: trash} do
+    f1 = create_file!(trash, "newfile")
+    wait_next_sec(f1)
+
+    dirty = FileSnapshot.dirty()
+    assert FileSnapshot.modified?(dirty, f1) == true
+
+    assert to_string(dirty) == "DIRTY"
+  end
+
+  describe "set_clean/2" do
+    test "without delay", %{trash: trash} do
+      f1 = create_file!(trash, "newfile")
+      wait_next_sec(f1)
+
+      save = FileSnapshot.save(f1)
+      assert FileSnapshot.modified?(save, f1) == true
+
+      # an abuse of the API, but best we can do
+      FileSnapshot.set_clean(save, save)
+      assert FileSnapshot.modified?(save, f1) == false
+    end
+
+    test "with (faked) delay", %{trash: trash} do
+      f1 = create_file!(trash, "newfile")
+      wait_next_sec(f1)
+
+      save = FileSnapshot.save(f1)
+      assert FileSnapshot.modified?(save, f1) == true
+
+      modified_earlier = %{save | last_modified: save.last_modified - 10}
+      FileSnapshot.set_clean(modified_earlier, save)
+      assert FileSnapshot.modified?(modified_earlier, f1) == true
+    end
+  end
+
+  defp create_file!(trash, leaf_name) when is_binary(trash) and is_binary(leaf_name) do
+    path = Path.expand(leaf_name, trash)
+    File.touch!(path)
+    path
+  end
+
+  defp append!(path, b) when is_binary(path) and is_list(b), do: File.write!(path, b, [:append])
+end


### PR DESCRIPTION
## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] There is test coverage for all changes.
- [x] Any code ported from jgit maintains all existing copyright and license notices.
- [x] If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.
- [ ] ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
