### PR TITLE
Implement Xgit.Core.DirCache.empty/0, which returns a canonical "empty" dir cache.

### DIFF
--- a/lib/xgit/core/dir_cache.ex
+++ b/lib/xgit/core/dir_cache.ex
@@ -220,6 +220,12 @@ defmodule Xgit.Core.DirCache do
   end
 
   @doc ~S"""
+  Returns a dir cache that is the canonical "empty" dir cache (i.e. contains no entries).
+  """
+  @spec empty() :: t
+  def empty, do: %__MODULE__{version: 2, entry_count: 0, entries: []}
+
+  @doc ~S"""
   Return `true` if this entry struct describes a valid dir cache.
   """
   @spec valid?(dir_cache :: any) :: boolean

--- a/test/xgit/core/dir_cache_test.exs
+++ b/test/xgit/core/dir_cache_test.exs
@@ -4,6 +4,11 @@ defmodule Xgit.Core.DirCacheTest do
   alias Xgit.Core.DirCache
   alias Xgit.Core.DirCache.Entry
 
+  describe "empty/0" do
+    assert %DirCache{version: 2, entry_count: 0, entries: []} = empty = DirCache.empty()
+    assert DirCache.valid?(empty)
+  end
+
   describe "valid?/1" do
     @valid_entry %Entry{
       name: 'hello.txt',


### PR DESCRIPTION
## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] There is test coverage for all changes.
- [ ] ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- [ ] ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- [ ] ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
