### PR TITLE
Implement Xgit.Plumbing.LsFiles.Stage.

### DIFF
--- a/lib/xgit/plumbing/ls_files/stage.ex
+++ b/lib/xgit/plumbing/ls_files/stage.ex
@@ -1,0 +1,57 @@
+defmodule Xgit.Plumbing.LsFiles.Stage do
+  @moduledoc ~S"""
+  Show information about files in the index.
+
+  Analogous to
+  [`git ls-files --stage`](https://git-scm.com/docs/git-ls-files#Documentation/git-ls-files.txt---stage).
+  """
+
+  alias Xgit.Core.DirCache
+  alias Xgit.Core.DirCache.Entry, as: DirCacheEntry
+  alias Xgit.Repository
+  alias Xgit.Repository.WorkingTree
+  alias Xgit.Repository.WorkingTree.ParseIndexFile
+
+  @typedoc ~S"""
+  Reason codes that can be returned by `run/1`.
+  """
+  @type reason :: :invalid_repository | ParseIndexFile.from_iodevice_reason()
+
+  @doc ~S"""
+  Retrieves information about files in the working tree as described by the index file.
+
+  ## Parameters
+
+  `repository` is the `Xgit.Repository` (PID) to search for the object.
+
+  ## Return Value
+
+  `{:ok, entries}`. `entries` will be a list of `Xgit.Core.DirCache.Entry` structs
+  in sorted order.
+
+  `{:error, :invalid_repository}` if `repository` doesn't represent a valid
+  `Xgit.Repository` process.
+
+  `{:error, :bare}` if `repository` doesn't have a working tree.
+
+  `{:error, reason}` if the index file for `repository` isn't valid. (See
+  `Xgit.Repository.WorkingTree.ParseIndexFile.from_iodevice/1` for possible
+  reason codes.)
+  """
+  @spec run(repository :: Repository.t()) ::
+          {:ok, entries :: [DirCacheEntry.t()]}
+          | {:error, reason :: reason}
+  def run(repository) when is_pid(repository) do
+    with {:repository_valid?, true} <- {:repository_valid?, Repository.valid?(repository)},
+         {:working_tree, working_tree} when is_pid(working_tree) <-
+           {:working_tree, Repository.default_working_tree(repository)},
+         {:dir_cache, {:ok, %DirCache{entries: entries} = _dir_cache}} <-
+           {:dir_cache, WorkingTree.dir_cache(working_tree)} do
+      {:ok, entries}
+    else
+      {:repository_valid?, false} -> {:error, :invalid_repository}
+      {:working_tree, nil} -> {:error, :bare}
+      {:dir_cache, {:error, reason}} -> {:error, reason}
+    end
+  end
+end

--- a/test/xgit/plumbing/ls_files/stage_test.exs
+++ b/test/xgit/plumbing/ls_files/stage_test.exs
@@ -1,0 +1,157 @@
+defmodule Xgit.Plumbing.LsFiles.StageTest do
+  use Xgit.GitInitTestCase, async: true
+
+  alias Xgit.Core.DirCache.Entry, as: DirCacheEntry
+  alias Xgit.Plumbing.LsFiles.Stage, as: LsFilesStage
+  alias Xgit.Repository
+  alias Xgit.Repository.InMemory
+  alias Xgit.Repository.OnDisk
+  alias Xgit.Repository.WorkingTree
+
+  describe "dir_cache/1" do
+    test "happy path: no index file" do
+      {:ok, repo} = InMemory.start_link()
+
+      Temp.track!()
+      path = Temp.mkdir!()
+
+      {:ok, working_tree} = WorkingTree.start_link(repo, path)
+      :ok = Repository.set_default_working_tree(repo, working_tree)
+
+      assert {:ok, []} = LsFilesStage.run(repo)
+    end
+
+    test "happy path: can read from command-line git (empty index)", %{ref: ref} do
+      {_output, 0} =
+        System.cmd(
+          "git",
+          [
+            "update-index",
+            "--add",
+            "--cacheinfo",
+            "100644",
+            "18832d35117ef2f013c4009f5b2128dfaeff354f",
+            "hello.txt"
+          ],
+          cd: ref
+        )
+
+      {_output, 0} =
+        System.cmd(
+          "git",
+          [
+            "update-index",
+            "--remove",
+            "hello.txt"
+          ],
+          cd: ref
+        )
+
+      {:ok, repo} = OnDisk.start_link(work_dir: ref)
+      assert {:ok, []} = LsFilesStage.run(repo)
+    end
+
+    test "happy path: can read from command-line git (two small files)", %{ref: ref} do
+      {_output, 0} =
+        System.cmd(
+          "git",
+          [
+            "update-index",
+            "--add",
+            "--cacheinfo",
+            "100644",
+            "18832d35117ef2f013c4009f5b2128dfaeff354f",
+            "hello.txt"
+          ],
+          cd: ref
+        )
+
+      {_output, 0} =
+        System.cmd(
+          "git",
+          [
+            "update-index",
+            "--add",
+            "--cacheinfo",
+            "100644",
+            "d670460b4b4aece5915caf5c68d12f560a9fe3e4",
+            "test_content.txt"
+          ],
+          cd: ref
+        )
+
+      {:ok, repo} = OnDisk.start_link(work_dir: ref)
+
+      assert {:ok, entries} = LsFilesStage.run(repo)
+
+      assert entries = [
+               %DirCacheEntry{
+                 assume_valid?: false,
+                 ctime: 0,
+                 ctime_ns: 0,
+                 dev: 0,
+                 extended?: false,
+                 gid: 0,
+                 ino: 0,
+                 intent_to_add?: false,
+                 mode: 0o100644,
+                 mtime: 0,
+                 mtime_ns: 0,
+                 name: 'hello.txt',
+                 object_id: "18832d35117ef2f013c4009f5b2128dfaeff354f",
+                 size: 0,
+                 skip_worktree?: false,
+                 stage: 0,
+                 uid: 0
+               },
+               %DirCacheEntry{
+                 assume_valid?: false,
+                 ctime: 0,
+                 ctime_ns: 0,
+                 dev: 0,
+                 extended?: false,
+                 gid: 0,
+                 ino: 0,
+                 intent_to_add?: false,
+                 mode: 0o100644,
+                 mtime: 0,
+                 mtime_ns: 0,
+                 name: 'test_content.txt',
+                 object_id: "d670460b4b4aece5915caf5c68d12f560a9fe3e4",
+                 size: 0,
+                 skip_worktree?: false,
+                 stage: 0,
+                 uid: 0
+               }
+             ]
+    end
+
+    test "error: repository invalid (not PID)" do
+      assert_raise FunctionClauseError, fn ->
+        LsFilesStage.run("xgit repo")
+      end
+    end
+
+    test "error: repository invalid (PID, but not repo)" do
+      {:ok, not_repo} = GenServer.start_link(NotValid, nil)
+      assert {:error, :invalid_repository} = LsFilesStage.run(not_repo)
+    end
+
+    test "error: no working tree" do
+      {:ok, repo} = InMemory.start_link()
+      assert {:error, :bare} = LsFilesStage.run(repo)
+    end
+
+    test "error: invalid index file", %{xgit: xgit} do
+      git_dir = Path.join(xgit, ".git")
+      File.mkdir_p!(git_dir)
+
+      index_path = Path.join(git_dir, "index")
+      File.write!(index_path, "DIRX")
+
+      {:ok, repo} = OnDisk.start_link(work_dir: xgit)
+
+      assert {:error, :invalid_format} = LsFilesStage.run(repo)
+    end
+  end
+end


### PR DESCRIPTION
## Changes in This Pull Request
This is an API equivalent of `git ls-files --stage`.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] There is test coverage for all changes.
- [ ] ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- [ ] ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- [ ] ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
