### PR TITLE
Implement Xgit.Util.TrailingHashReadDevice.

### DIFF
--- a/lib/xgit/util/trailing_hash_read_device.ex
+++ b/lib/xgit/util/trailing_hash_read_device.ex
@@ -1,0 +1,153 @@
+defmodule Xgit.Util.TrailingHashReadDevice do
+  @moduledoc ~S"""
+  Creates an `iodevice` process that reads the file or string content except
+  for the trailing 20 bytes.
+
+  The trailing 20 bytes are interpreted as a SHA-1 hash of the remaining file
+  contents and can be verified using the `valid_hash?/1` function.
+
+  This is an admittedly minimal implementation; just enough is implemented to
+  allow Xgit's index file parser to do its work.
+  """
+  use GenServer
+
+  require Logger
+
+  @doc ~S"""
+  Creates an IO device that reads a file with trailing hash.
+
+  Unlike `File.open/2` and `File.open/3`, no options or function are
+  accepted.
+
+  This device can be passed to `IO.binread/2`.
+
+  ## Return Value
+
+  `{:ok, pid}` where `pid` points to an IO device process.
+
+  `{:ok, reason}` if the file could not be opened. See `File.open/2` for
+  possible values for `reason`.
+  """
+  @spec open_file(path :: Path.t()) :: {:ok, pid} | {:error, File.posix()}
+  def open_file(path) when is_binary(path),
+    do: GenServer.start_link(__MODULE__, {:file, path})
+
+  @doc ~S"""
+  Creates an IO device that reads a string with trailing hash.
+
+  This is intended mostly for internal testing purposes.
+
+  Unlike `StringIO.open/2` and `StringIO.open/3`, no options or function are
+  accepted.
+
+  This device can be passed to `IO.binread/2`.
+
+  ## Return Value
+
+  `{:ok, pid}` where `pid` points to an IO device process.
+  """
+  @spec open_string(s :: binary) :: {:ok, pid}
+  def open_string(s) when is_binary(s) and byte_size(s) >= 20,
+    do: GenServer.start_link(__MODULE__, {:string, s})
+
+  @doc ~S"""
+  Returns `true` if the hash at the end of the file matches the hash
+  generated while reading the file.
+
+  Should only be called once and only once when the entire file (sans SHA-1 hash)
+  has been read.
+
+  ## Return Values
+
+  `true` or `false` if the SHA-1 hash was found and was valid (or not).
+
+  `:too_soon` if called before the SHA-1 hash is expected.
+
+  `:already_called` if called a second (or successive) time.
+  """
+  @spec valid_hash?(io_device :: pid) :: boolean
+  def valid_hash?(io_device) when is_pid(io_device),
+    do: GenServer.call(io_device, :valid_hash?)
+
+  @impl true
+  def init({:file, path}) do
+    with {:ok, %{size: size}} <- File.stat(path, time: :posix),
+         {:ok, pid} when is_pid(pid) <- File.open(path) do
+      {:ok, %{iodevice: pid, remaining_bytes: size - 20, crypto: :crypto.hash_init(:sha)}}
+    else
+      {:error, reason} -> {:stop, reason}
+    end
+  end
+
+  def init({:string, s}) do
+    {:ok, pid} = StringIO.open(s)
+    {:ok, %{iodevice: pid, remaining_bytes: byte_size(s) - 20, crypto: :crypto.hash_init(:sha)}}
+  end
+
+  @impl true
+  def handle_info({:io_request, from, reply_as, req}, state) do
+    state = io_request(from, reply_as, req, state)
+    {:noreply, state}
+  end
+
+  def handle_info(message, state) do
+    Logger.warn("TrailingHashReadDevice received unexpected message #{inspect(message)}")
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_call(:valid_hash?, _from, %{remaining_bytes: 0, crypto: :done} = state),
+    do: {:reply, :already_called, state}
+
+  def handle_call(
+        :valid_hash?,
+        _from,
+        %{iodevice: iodevice, remaining_bytes: remaining_bytes, crypto: crypto} = state
+      )
+      when remaining_bytes <= 0 do
+    actual_hash = :crypto.hash_final(crypto)
+    hash_from_file = IO.binread(iodevice, 20)
+
+    {:reply, actual_hash == hash_from_file, %{state | iodevice: nil, crypto: :done}}
+  end
+
+  def handle_call(:valid_hash?, _from, state), do: {:reply, :too_soon, state}
+
+  def handle_call(request, _from, state) do
+    Logger.warn("TrailingHashReadDevice received unexpected call #{inspect(request)}")
+    {:reply, :unknown_message, state}
+  end
+
+  defp io_request(from, reply_as, req, state) do
+    {reply, state} = io_request(req, state)
+    send(from, {:io_reply, reply_as, reply})
+    state
+  end
+
+  defp io_request({:get_chars, :"", count}, %{remaining_bytes: remaining_bytes} = state)
+       when remaining_bytes <= 0 and is_integer(count) and count >= 0 do
+    {:eof, state}
+  end
+
+  defp io_request({:get_chars, :"", 0}, state), do: {"", state}
+
+  defp io_request(
+         {:get_chars, :"", count},
+         %{iodevice: iodevice, remaining_bytes: remaining_bytes, crypto: crypto} = state
+       )
+       when is_integer(count) and count > 0 do
+    data = IO.binread(iodevice, min(remaining_bytes, count))
+
+    if is_binary(data) do
+      crypto = :crypto.hash_update(crypto, data)
+      {data, %{state | remaining_bytes: remaining_bytes - byte_size(data), crypto: crypto}}
+    else
+      {data, state}
+    end
+  end
+
+  defp io_request(request, state) do
+    Logger.warn("TrailingHashReadDevice received unexpected iorequest #{inspect(request)}")
+    {{:error, :request}, state}
+  end
+end

--- a/test/xgit/util/trailing_hash_read_device_test.exs
+++ b/test/xgit/util/trailing_hash_read_device_test.exs
@@ -1,0 +1,171 @@
+defmodule Xgit.Util.TrailingHashReadDeviceTest do
+  use ExUnit.Case, async: true
+
+  alias Xgit.Util.TrailingHashReadDevice, as: THR
+
+  import ExUnit.CaptureLog
+
+  describe "test infrastructure" do
+    test "string_with_trailing_hash/1" do
+      s = string_with_trailing_hash("hello")
+
+      assert byte_size(s) == 25
+
+      assert s ==
+               "hello" <>
+                 <<170, 244, 198, 29, 220, 197, 232, 162, 218, 190, 222, 15, 59, 72, 44, 217, 174,
+                   169, 67, 77>>
+    end
+  end
+
+  describe "open_file/1" do
+    test "simple file" do
+      assert {:ok, device} = open_file_with_trailing_hash("hello")
+
+      assert "hello" = IO.binread(device, 5)
+      assert :eof = IO.binread(device, 5)
+
+      assert THR.valid_hash?(device)
+    end
+
+    test "multiple reads" do
+      assert {:ok, device} = open_file_with_trailing_hash("hello, goodbye")
+
+      assert "hello" = IO.binread(device, 5)
+      assert ", " = IO.binread(device, 2)
+      assert "goodbye" = IO.binread(device, 7)
+      assert :eof = IO.binread(device, 1)
+
+      assert THR.valid_hash?(device)
+    end
+
+    test "immediate EOF if file is <= 20 bytes long" do
+      Temp.track!()
+      path = Temp.path!()
+
+      File.write!(path, "hello")
+
+      assert {:ok, device} = THR.open_file(path)
+      assert is_pid(device)
+
+      assert :eof = IO.binread(device, 5)
+
+      refute THR.valid_hash?(device)
+    end
+
+    test "hash is invalid" do
+      Temp.track!()
+      path = Temp.path!()
+
+      File.write!(path, "hellobogusbogusbogusbogus")
+
+      assert {:ok, device} = THR.open_file(path)
+      assert is_pid(device)
+
+      assert "hello" = IO.binread(device, 5)
+      assert :eof = IO.binread(device, 5)
+
+      refute THR.valid_hash?(device)
+    end
+
+    test "Posix error" do
+      Temp.track!()
+      path = Temp.path!()
+      File.mkdir_p!(path)
+
+      assert {:error, :eisdir} = THR.open_file(path)
+    end
+
+    test "error :too_soon" do
+      assert {:ok, device} = open_file_with_trailing_hash("hello, goodbye")
+
+      assert "hello" = IO.binread(device, 5)
+      assert THR.valid_hash?(device) == :too_soon
+    end
+
+    test "error :already_called" do
+      assert {:ok, device} = open_file_with_trailing_hash("hello")
+
+      assert "hello" = IO.binread(device, 5)
+      assert :eof = IO.binread(device, 5)
+
+      assert THR.valid_hash?(device)
+      assert THR.valid_hash?(device) == :already_called
+    end
+
+    test "error: unexpected io request" do
+      assert {:ok, device} = open_file_with_trailing_hash("hello")
+
+      assert capture_log(fn ->
+               assert {:error, :request} = IO.binwrite(device, "hello")
+             end) =~
+               ~s(TrailingHashReadDevice received unexpected iorequest {:put_chars, :latin1, "hello"})
+    end
+
+    test "warn: unexpected message" do
+      assert {:ok, device} = open_file_with_trailing_hash("hello, goodbye")
+
+      assert capture_log(fn ->
+               send(device, :random_unknown_message)
+             end) =~ "TrailingHashReadDevice received unexpected message :random_unknown_message"
+    end
+
+    test "warn: unexpected call" do
+      assert {:ok, device} = open_file_with_trailing_hash("hello, goodbye")
+
+      assert capture_log(fn ->
+               assert :unknown_message = GenServer.call(device, :random_unknown_call)
+             end) =~ "TrailingHashReadDevice received unexpected call :random_unknown_call"
+    end
+  end
+
+  describe "open_string/1" do
+    test "simple file" do
+      assert {:ok, device} = open_string_with_trailing_hash("hello")
+
+      assert "hello" = IO.binread(device, 5)
+      assert :eof = IO.binread(device, 5)
+
+      assert THR.valid_hash?(device)
+    end
+
+    test "FunctionClauseError if string is <= 20 bytes long" do
+      assert_raise FunctionClauseError, fn ->
+        THR.open_string("hello")
+      end
+    end
+
+    test "hash is invalid" do
+      assert {:ok, device} = THR.open_string("hellobogusbogusbogusbogus")
+
+      assert "hello" = IO.binread(device, 5)
+      assert :eof = IO.binread(device, 5)
+
+      refute THR.valid_hash?(device)
+    end
+  end
+
+  defp open_file_with_trailing_hash(s) do
+    Temp.track!()
+    path = Temp.path!()
+
+    File.write!(path, string_with_trailing_hash(s))
+
+    THR.open_file(path)
+  end
+
+  defp open_string_with_trailing_hash(s) do
+    s
+    |> string_with_trailing_hash()
+    |> THR.open_string()
+  end
+
+  defp string_with_trailing_hash(s), do: s <> hash_for_string(s)
+
+  defp hash_for_string(s) do
+    :sha
+    |> :crypto.hash_init()
+    |> :crypto.hash_update(s)
+    |> :crypto.hash_final()
+  end
+end


### PR DESCRIPTION
## Changes in This Pull Request
Parses a string or file in which the trailing 20 bytes are a SHA-1 hash of the preceding contents.

Pretends to reach :eof at (actual EOF - 20 bytes).

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] There is test coverage for all changes.
- [ ] ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- [ ] ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- [ ] ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
