### PR TITLE
ParseIndexFile now uses TrailingHashDevice to validate SHA-1 hash …

### DIFF
--- a/lib/xgit/repository/working_tree.ex
+++ b/lib/xgit/repository/working_tree.ex
@@ -21,6 +21,7 @@ defmodule Xgit.Repository.WorkingTree do
   alias Xgit.Core.DirCache
   alias Xgit.Repository
   alias Xgit.Repository.WorkingTree.ParseIndexFile
+  alias Xgit.Util.TrailingHashDevice
 
   require Logger
 
@@ -114,7 +115,7 @@ defmodule Xgit.Repository.WorkingTree do
     index_path = Path.join([work_dir, ".git", "index"])
 
     with true <- File.exists?(index_path),
-         {:ok, iodevice} when is_pid(iodevice) <- File.open(index_path) do
+         {:ok, iodevice} when is_pid(iodevice) <- TrailingHashDevice.open_file(index_path) do
       res = ParseIndexFile.from_iodevice(iodevice)
       :ok = File.close(iodevice)
 

--- a/lib/xgit/repository/working_tree/parse_index_file.ex
+++ b/lib/xgit/repository/working_tree/parse_index_file.ex
@@ -10,6 +10,7 @@ defmodule Xgit.Repository.WorkingTree.ParseIndexFile do
   alias Xgit.Core.DirCache
   alias Xgit.Core.DirCache.Entry, as: DirCacheEntry
   alias Xgit.Util.NB
+  alias Xgit.Util.TrailingHashDevice
 
   @typedoc ~S"""
   Error codes which can be returned by `from_iodevice/1`.
@@ -20,9 +21,14 @@ defmodule Xgit.Repository.WorkingTree.ParseIndexFile do
   Read index file from an `IO.device` (typically an opened file) and returns a
   corresponding `Xgit.Core.DirCache` struct.
 
+  _IMPORTANT:_ The `IO.device` must be created using `Xgit.Util.TrailingHashDevice`.
+
   ## Return Value
 
   `{:ok, dir_cache}` if the iodevice contains a valid index file.
+
+  `{:error, :not_sha_hash_device}` if the iodevice was not created using
+  `Xgit.Util.TrailingHashDevice`.
 
   `{:error, :invalid_format}` if the iodevice can not be parsed as an index file.
 
@@ -32,20 +38,29 @@ defmodule Xgit.Repository.WorkingTree.ParseIndexFile do
   `{:error, :too_many_entries}` if the index files contains more than 100,000
   entries. This is an arbitrary limit to guard against malformed files and to
   prevent overconsumption of memory. With experience, it could be revisited.
+
+  `{:error, :extensions_not_supported}` if any index file extensions are present.
+  Parsing extensions is not yet supported. (See
+  [issue #67](https://github.com/elixir-git/xgit/issues/67).)
+
+  `{:error, :sha_hash_mismatch}` if the SHA-1 hash written at the end of the file
+  does not match the file contents.
   """
   @spec from_iodevice(iodevice :: IO.device()) ::
           {:ok, dir_cache :: DirCache.t()} | {:error, reason :: from_iodevice_reason}
   def from_iodevice(iodevice) do
-    with {:dirc, true} <- {:dirc, read_dirc(iodevice)},
+    with {:sha_hash_device, true} <- {:sha_hash_device, TrailingHashDevice.valid?(iodevice)},
+         {:dirc, true} <- {:dirc, read_dirc(iodevice)},
          {:version, version = 2} <- {:version, read_uint32(iodevice)},
          {:entry_count, entry_count}
          when is_integer(entry_count) and entry_count <= 100_000 <-
            {:entry_count, read_uint32(iodevice)},
          {:entries, entries} when is_list(entries) <-
-           {:entries, read_entries(iodevice, version, entry_count)} do
-      # TO DO: Parse extensions and trailing checksum.
-      # https://github.com/elixir-git/xgit/issues/67
-
+           {:entries, read_entries(iodevice, version, entry_count)},
+         {:extensions, :eof} <- {:extensions, IO.binread(iodevice, 1)},
+         # TO DO: Parse extensions. For now, error out if any are present.
+         # https://github.com/elixir-git/xgit/issues/67
+         {:sha_valid?, true} <- {:sha_valid?, TrailingHashDevice.valid_hash?(iodevice)} do
       {:ok,
        %DirCache{
          version: version,
@@ -53,11 +68,14 @@ defmodule Xgit.Repository.WorkingTree.ParseIndexFile do
          entries: entries
        }}
     else
+      {:sha_hash_device, _} -> {:error, :not_sha_hash_device}
       {:dirc, _} -> {:error, :invalid_format}
       {:version, _} -> {:error, :unsupported_version}
       {:entry_count, :invalid} -> {:error, :invalid_format}
       {:entry_count, _} -> {:error, :too_many_entries}
       {:entries, _} -> {:error, :invalid_format}
+      {:extensions, _} -> {:error, :extensions_not_supported}
+      {:sha_valid?, _} -> {:error, :sha_hash_mismatch}
     end
   end
 

--- a/test/xgit/repository/working_tree/dir_cache_test.exs
+++ b/test/xgit/repository/working_tree/dir_cache_test.exs
@@ -139,7 +139,33 @@ defmodule Xgit.Repository.WorkingTree.DirCacheTest do
 
     test "error: unsupported version", %{xgit: xgit} do
       assert {:error, :unsupported_version} =
-               parse_iodata_as_index_file(xgit, ['DIRC', 0, 0, 0, 1])
+               parse_iodata_as_index_file(xgit, [
+                 'DIRC',
+                 0,
+                 0,
+                 0,
+                 1,
+                 0,
+                 0,
+                 0,
+                 0,
+                 0,
+                 0,
+                 0,
+                 0,
+                 0,
+                 0,
+                 0,
+                 0,
+                 0,
+                 0,
+                 0,
+                 0,
+                 0,
+                 0,
+                 0,
+                 0
+               ])
     end
 
     test "error: 'index' is a directory", %{xgit: xgit} do


### PR DESCRIPTION
… at end of index file.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] There is test coverage for all changes.
- [ ] ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- [ ] ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
