### PR TITLE
Fix @type declaration for ParseIndexFile.from_iodevice_reason.

### DIFF
--- a/lib/xgit/repository/working_tree/parse_index_file.ex
+++ b/lib/xgit/repository/working_tree/parse_index_file.ex
@@ -15,7 +15,14 @@ defmodule Xgit.Repository.WorkingTree.ParseIndexFile do
   @typedoc ~S"""
   Error codes which can be returned by `from_iodevice/1`.
   """
-  @type from_iodevice_reason :: :invalid_format | :unsupported_version | :too_many_entries
+  @type from_iodevice_reason ::
+          :not_sha_hash_device
+          | :invalid_format
+          | :unsupported_version
+          | :too_many_entries
+          | :extensions_not_supported
+          | :sha_hash_mismatch
+          | File.posix()
 
   @doc ~S"""
   Read index file from an `IO.device` (typically an opened file) and returns a


### PR DESCRIPTION
## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [ ] ~There is test coverage for all changes.~ _n/a_
- [ ] ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- [ ] ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- [ ] ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
