### PR TITLE
Implement Xgit.Plumbing.UpdateIndex.CacheInfo.

### DIFF
--- a/lib/xgit/plumbing/update_index/cache_info.ex
+++ b/lib/xgit/plumbing/update_index/cache_info.ex
@@ -1,0 +1,123 @@
+defmodule Xgit.Plumbing.UpdateIndex.CacheInfo do
+  @moduledoc ~S"""
+  Update the index file to reflect new contents.
+
+  Analogous to the `--cacheinfo` form of
+  [`git update-index`](https://git-scm.com/docs/git-update-index#Documentation/git-update-index.txt---cacheinfoltmodegtltobjectgtltpathgt).
+  """
+  use Xgit.Core.FileMode
+
+  alias Xgit.Core.DirCache.Entry, as: DirCacheEntry
+  alias Xgit.Core.ObjectId
+  alias Xgit.Core.ValidatePath
+  alias Xgit.Repository
+  alias Xgit.Repository.WorkingTree
+
+  @typedoc ~S"""
+  Cache info tuple `{mode, object_id, path}` to add to the index file.
+  """
+  @type add_entry :: {mode :: FileMode.t(), object_id :: ObjectId.t(), path :: [byte]}
+
+  @typedoc ~S"""
+  Reason codes that can be returned by `run/2`.
+  """
+  @type reason ::
+          :invalid_repository
+          | :invalid_entry
+          | :bare
+          | Xgit.Repository.WorkingTree.update_dir_cache_reason()
+
+  @doc ~S"""
+  Update the index file to reflect new contents.
+
+  ## Parameters
+
+  `repository` is the `Xgit.Repository` (PID) to which the new entries should be written.
+
+  `add`: a list of tuples of `{mode, object_id, path}` entries to add to the dir cache.
+  In the event of collisions with existing entries, the existing entries will
+  be replaced with the corresponding new entries.
+
+  `remove`: a list of paths to remove from the dir cache. All versions of the file,
+  regardless of stage, will be removed.
+
+  ## Return Value
+
+  `:ok` if successful.
+
+  `{:error, :invalid_repository}` if `repository` doesn't represent a valid
+  `Xgit.Repository` process.
+
+  `{:error, :bare}` if `repository` doesn't have a working tree.
+
+  `{:error, :invalid_entry}` if any tuple passed to `add` or `remove` was invalid.
+
+  `{:error, :reason}` if unable. The relevant reason codes may come from
+  `Xgit.Repository.WorkingTree.update_dir_cache/3`.
+  """
+  @spec run(repository :: Repository.t(), add :: [add_entry], remove :: [byte]) ::
+          :ok | {:error, reason()}
+  def run(repository, add, remove \\ [])
+      when is_pid(repository) and is_list(add) and is_list(remove) do
+    with {:repository_valid?, true} <- {:repository_valid?, Repository.valid?(repository)},
+         {:items_to_add, add} when is_list(add) <- {:items_to_add, parse_add_entries(add)},
+         {:items_to_remove, remove} when is_list(remove) <-
+           {:items_to_remove, parse_remove_entries(remove)},
+         {:working_tree, working_tree} when is_pid(working_tree) <-
+           {:working_tree, Repository.default_working_tree(repository)} do
+      WorkingTree.update_dir_cache(working_tree, add, remove)
+    else
+      {:repository_valid?, false} -> {:error, :invalid_repository}
+      {:items_to_add, _} -> {:error, :invalid_entry}
+      {:items_to_remove, _} -> {:error, :invalid_entry}
+      {:working_tree, nil} -> {:error, :bare}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp parse_add_entries(add) do
+    if Enum.all?(add, &valid_add?/1),
+      do: Enum.map(add, &map_add_entry/1),
+      else: :invalid
+  end
+
+  defp valid_add?({mode, object_id, path})
+       when is_file_mode(mode) and is_binary(object_id) and is_list(path) do
+    ObjectId.valid?(object_id) and ValidatePath.check_path(path)
+  end
+
+  defp valid_add?(_), do: false
+
+  defp map_add_entry({mode, object_id, path}) do
+    %DirCacheEntry{
+      name: path,
+      stage: 0,
+      object_id: object_id,
+      mode: mode,
+      size: 0,
+      ctime: 0,
+      ctime_ns: 0,
+      mtime: 0,
+      mtime_ns: 0,
+      dev: 0,
+      ino: 0,
+      uid: 0,
+      gid: 0,
+      assume_valid?: false,
+      extended?: false,
+      skip_worktree?: false,
+      intent_to_add?: false
+    }
+  end
+
+  defp parse_remove_entries(remove) do
+    if Enum.all?(remove, &valid_remove?/1),
+      do: Enum.map(remove, &map_remove_entry/1),
+      else: :invalid
+  end
+
+  defp valid_remove?(name) when is_list(name), do: true
+  defp valid_remove?(_), do: false
+
+  defp map_remove_entry(name), do: {name, :all}
+end

--- a/lib/xgit/repository/working_tree.ex
+++ b/lib/xgit/repository/working_tree.ex
@@ -19,6 +19,7 @@ defmodule Xgit.Repository.WorkingTree do
   use GenServer
 
   alias Xgit.Core.DirCache
+  alias Xgit.Core.DirCache.Entry, as: DirCacheEntry
   alias Xgit.Repository
   alias Xgit.Repository.WorkingTree.ParseIndexFile
   alias Xgit.Repository.WorkingTree.WriteIndexFile

--- a/test/xgit/plumbing/update_index/cache_info_test.exs
+++ b/test/xgit/plumbing/update_index/cache_info_test.exs
@@ -1,0 +1,251 @@
+defmodule Xgit.Plumbing.UpdateInfo.CacheInfoTest do
+  use Xgit.GitInitTestCase, async: true
+
+  alias Xgit.Plumbing.UpdateIndex.CacheInfo
+  alias Xgit.Repository.InMemory
+  alias Xgit.Repository.OnDisk
+
+  import FolderDiff
+
+  describe "run/2" do
+    test "happy path: write to repo matches command-line git (one file)", %{ref: ref, xgit: xgit} do
+      {_output, 0} =
+        System.cmd(
+          "git",
+          [
+            "update-index",
+            "--add",
+            "--cacheinfo",
+            "100644",
+            "18832d35117ef2f013c4009f5b2128dfaeff354f",
+            "hello.txt"
+          ],
+          cd: ref
+        )
+
+      assert :ok = OnDisk.create(xgit)
+      assert {:ok, repo} = OnDisk.start_link(work_dir: xgit)
+
+      assert :ok =
+               CacheInfo.run(
+                 repo,
+                 [{0o100644, "18832d35117ef2f013c4009f5b2128dfaeff354f", 'hello.txt'}]
+               )
+
+      assert_folders_are_equal(ref, xgit)
+    end
+
+    test "happy path: git ls-files can read output from UpdateIndex.CacheInfo (one file)", %{
+      ref: ref
+    } do
+      {:ok, repo} = OnDisk.start_link(work_dir: ref)
+
+      assert :ok =
+               CacheInfo.run(
+                 repo,
+                 [{0o100644, "18832d35117ef2f013c4009f5b2128dfaeff354f", 'hello.txt'}]
+               )
+
+      assert {output, 0} = System.cmd("git", ["ls-files", "--stage"], cd: ref)
+      assert output == "100644 18832d35117ef2f013c4009f5b2128dfaeff354f 0	hello.txt\n"
+    end
+
+    test "happy path: can generate correct empty index file",
+         %{ref: ref, xgit: xgit} do
+      # An initialized git repo doesn't have an index file at all.
+      # Adding and removing a file generates an empty index file.
+
+      {_output, 0} =
+        System.cmd(
+          "git",
+          [
+            "update-index",
+            "--add",
+            "--cacheinfo",
+            "100644",
+            "18832d35117ef2f013c4009f5b2128dfaeff354f",
+            "hello.txt"
+          ],
+          cd: ref
+        )
+
+      {_output, 0} =
+        System.cmd(
+          "git",
+          [
+            "update-index",
+            "--remove",
+            "hello.txt"
+          ],
+          cd: ref
+        )
+
+      assert :ok = OnDisk.create(xgit)
+      {:ok, repo} = OnDisk.start_link(work_dir: xgit)
+
+      assert :ok = CacheInfo.run(repo, [])
+
+      assert_folders_are_equal(ref, xgit)
+    end
+
+    test "can write an index file with entries that matches command-line git",
+         %{ref: ref, xgit: xgit} do
+      {_output, 0} =
+        System.cmd(
+          "git",
+          [
+            "update-index",
+            "--add",
+            "--cacheinfo",
+            "100644",
+            "18832d35117ef2f013c4009f5b2128dfaeff354f",
+            "hello.txt"
+          ],
+          cd: ref
+        )
+
+      {_output, 0} =
+        System.cmd(
+          "git",
+          [
+            "update-index",
+            "--add",
+            "--cacheinfo",
+            "100644",
+            "d670460b4b4aece5915caf5c68d12f560a9fe3e4",
+            "test_content.txt"
+          ],
+          cd: ref
+        )
+
+      assert :ok = OnDisk.create(xgit)
+      {:ok, repo} = OnDisk.start_link(work_dir: xgit)
+
+      assert :ok =
+               CacheInfo.run(
+                 repo,
+                 [
+                   {0o100644, "18832d35117ef2f013c4009f5b2128dfaeff354f", 'hello.txt'},
+                   {0o100644, "d670460b4b4aece5915caf5c68d12f560a9fe3e4", 'test_content.txt'}
+                 ]
+               )
+
+      assert_folders_are_equal(ref, xgit)
+    end
+
+    test "can remove entries from index file",
+         %{ref: ref, xgit: xgit} do
+      {_output, 0} =
+        System.cmd(
+          "git",
+          [
+            "update-index",
+            "--add",
+            "--cacheinfo",
+            "100644",
+            "18832d35117ef2f013c4009f5b2128dfaeff354f",
+            "hello.txt"
+          ],
+          cd: ref
+        )
+
+      assert :ok = OnDisk.create(xgit)
+
+      # For variety, let's use command-line git to write the first index file
+      # and then update it with Xgit.
+
+      {_output, 0} =
+        System.cmd(
+          "git",
+          [
+            "update-index",
+            "--add",
+            "--cacheinfo",
+            "100644",
+            "18832d35117ef2f013c4009f5b2128dfaeff354f",
+            "hello.txt"
+          ],
+          cd: xgit
+        )
+
+      {_output, 0} =
+        System.cmd(
+          "git",
+          [
+            "update-index",
+            "--add",
+            "--cacheinfo",
+            "100644",
+            "d670460b4b4aece5915caf5c68d12f560a9fe3e4",
+            "test_content.txt"
+          ],
+          cd: xgit
+        )
+
+      {:ok, repo} = OnDisk.start_link(work_dir: xgit)
+
+      assert :ok = CacheInfo.run(repo, [], ['test_content.txt'])
+
+      assert_folders_are_equal(ref, xgit)
+    end
+
+    test "error: file doesn't start with DIRC signature", %{xgit: xgit} do
+      git_dir = Path.join(xgit, '.git')
+      File.mkdir_p!(git_dir)
+
+      index = Path.join(git_dir, 'index')
+      File.write!(index, 'DIRX12345678901234567890')
+
+      {:ok, repo} = OnDisk.start_link(work_dir: xgit)
+
+      assert {:error, :invalid_format} = CacheInfo.run(repo, [], ['test_content.txt'])
+    end
+
+    test "error: repository invalid (not PID)" do
+      assert_raise FunctionClauseError, fn ->
+        CacheInfo.run("xgit repo", [])
+      end
+    end
+
+    test "error: repository invalid (PID, but not repo)" do
+      {:ok, not_repo} = GenServer.start_link(NotValid, nil)
+      assert {:error, :invalid_repository} = CacheInfo.run(not_repo, [])
+    end
+
+    test "error: no working tree" do
+      {:ok, repo} = InMemory.start_link()
+      assert {:error, :bare} = CacheInfo.run(repo, [])
+    end
+
+    test "error: invalid index file", %{xgit: xgit} do
+      git_dir = Path.join(xgit, ".git")
+      File.mkdir_p!(git_dir)
+
+      index_path = Path.join(git_dir, "index")
+      File.write!(index_path, "DIRX")
+
+      {:ok, repo} = OnDisk.start_link(work_dir: xgit)
+
+      assert {:error, :invalid_format} = CacheInfo.run(repo, [])
+    end
+
+    test "error: invalid entries (add)", %{xgit: xgit} do
+      assert :ok = OnDisk.create(xgit)
+      {:ok, repo} = OnDisk.start_link(work_dir: xgit)
+
+      assert {:error, :invalid_entry} =
+               CacheInfo.run(repo, [
+                 {0o100644, "18832d35117ef2f013c4009f5b2128dfaeff354f", "hello.txt"}
+               ])
+
+      # Used a string for path here; path should be binary.
+    end
+
+    test "error: invalid entries (remove)", %{xgit: xgit} do
+      assert :ok = OnDisk.create(xgit)
+      {:ok, repo} = OnDisk.start_link(work_dir: xgit)
+
+      assert {:error, :invalid_entry} = CacheInfo.run(repo, [], ["should be a charlist"])
+    end
+  end
+end


### PR DESCRIPTION
## Changes in This Pull Request
Adds `Xgit.Plumbing.UpdateIndex.CacheInfo`, which is an API equivalent to `git update-index --cacheinfo`.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] There is test coverage for all changes.
- [ ] ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- [ ] ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- [ ] ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
