### PR TITLE
Introduce `stage` type for index file stage references.

### DIFF
--- a/lib/xgit/core/dir_cache.ex
+++ b/lib/xgit/core/dir_cache.ex
@@ -66,6 +66,16 @@ defmodule Xgit.Core.DirCache do
     alias Xgit.Core.ObjectId
 
     @typedoc ~S"""
+    Merge status (stage).
+    """
+    @type stage :: 0..3
+
+    @typedoc ~S"""
+    Merge status (stage) for matching a remove request. (Includes `:all` to match any stage.)
+    """
+    @type stage_match :: 0..3 | :all
+
+    @typedoc ~S"""
     A single file (or stage of a file) in a directory cache.
 
     An entry represents exactly one stage of a file. If a file path is unmerged
@@ -76,10 +86,10 @@ defmodule Xgit.Core.DirCache do
 
     ## Struct Members
 
-    * `name`: (FilePath.t) entry path name, relative to top-level directory (without leading slash)
-    * `stage`: 0..3 merge status
-    * `object_id`: (ObjectId.t) SHA-1 for the represented object
-    * `mode`: (FileMode.t)
+    * `name`: (`FilePath.t`) entry path name, relative to top-level directory (without leading slash)
+    * `stage`: (`0..3`) merge status
+    * `object_id`: (`ObjectId.t`) SHA-1 for the represented object
+    * `mode`: (`FileMode.t`)
     * `size`: (integer) on-disk size, possibly truncated to 32 bits
     * `ctime`: (integer) the last time the file's metadata changed
     * `ctime_ns`: (integer) nanosecond fraction of `ctime` (if available)
@@ -96,7 +106,7 @@ defmodule Xgit.Core.DirCache do
     """
     @type t :: %__MODULE__{
             name: FilePath.t(),
-            stage: 0..3,
+            stage: stage,
             object_id: ObjectId.t(),
             mode: FileMode.t(),
             size: non_neg_integer,
@@ -318,7 +328,7 @@ defmodule Xgit.Core.DirCache do
   @typedoc ~S"""
   An entry for the `remove` option for `remove_entries/2`.
   """
-  @type entry_to_remove :: {path :: FilePath.t(), stage :: 0..3 | :all}
+  @type entry_to_remove :: {path :: FilePath.t(), stage :: Entry.stage_match()}
 
   @typedoc ~S"""
   Error reason codes returned by `remove_entries/2`.
@@ -333,7 +343,7 @@ defmodule Xgit.Core.DirCache do
   `entries_to_remove` is a list of `{path, stage}` tuples identifying tuples to be removed.
 
   * `path` should be a byte list for the path.
-  * `stage` should be 0..3 or `:all`, meaning any entry that matches the path,
+  * `stage` should be `0..3` or `:all`, meaning any entry that matches the path,
     regardless of stage, should be removed.
 
   ## Return Value

--- a/lib/xgit/repository/working_tree.ex
+++ b/lib/xgit/repository/working_tree.ex
@@ -154,7 +154,7 @@ defmodule Xgit.Repository.WorkingTree do
   be replaced with the corresponding new entries.
 
   `remove`: a list of `{path, stage}` tuples to remove from the dir cache.
-  `stage` must be 0..3 to remove a specific stage entry or `:all` to match
+  `stage` must be `0..3` to remove a specific stage entry or `:all` to match
   any entry for the `path`.
 
   ## Return Values
@@ -180,7 +180,7 @@ defmodule Xgit.Repository.WorkingTree do
   @spec update_dir_cache(
           working_tree :: t,
           add :: [DirCacheEntry.t()],
-          remove :: [{[path :: [byte]], stage :: 0..3 | :all}]
+          remove :: [{[path :: [byte]], stage :: DirCacheEntry.stage_match()}]
         ) ::
           {:ok, DirCache.t()} | {:error, update_dir_cache_reason}
   def update_dir_cache(working_tree, add, remove)


### PR DESCRIPTION
## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] There is test coverage for all changes.
- [ ] ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- [ ] ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- [ ] ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
