### PR TITLE
Consistently format if/do/else statements using blocks.

### DIFF
--- a/lib/xgit/core/file_path.ex
+++ b/lib/xgit/core/file_path.ex
@@ -517,9 +517,11 @@ defmodule Xgit.Core.FilePath do
        do: cover(false)
 
   defp match_mac_hfs_path?([c | data], [m | match], ignorable?) do
-    if to_lower(c) == m,
-      do: match_mac_hfs_path?(data, match, ignorable?),
-      else: cover(false)
+    if to_lower(c) == m do
+      match_mac_hfs_path?(data, match, ignorable?)
+    else
+      cover(false)
+    end
   end
 
   defp match_mac_hfs_path?([], [], _ignorable?), do: cover(true)

--- a/lib/xgit/plumbing/update_index/cache_info.ex
+++ b/lib/xgit/plumbing/update_index/cache_info.ex
@@ -75,9 +75,11 @@ defmodule Xgit.Plumbing.UpdateIndex.CacheInfo do
   end
 
   defp parse_add_entries(add) do
-    if Enum.all?(add, &valid_add?/1),
-      do: Enum.map(add, &map_add_entry/1),
-      else: cover(:invalid)
+    if Enum.all?(add, &valid_add?/1) do
+      Enum.map(add, &map_add_entry/1)
+    else
+      cover(:invalid)
+    end
   end
 
   defp valid_add?({mode, object_id, path})
@@ -109,9 +111,11 @@ defmodule Xgit.Plumbing.UpdateIndex.CacheInfo do
   end
 
   defp parse_remove_entries(remove) do
-    if Enum.all?(remove, &valid_remove?/1),
-      do: Enum.map(remove, &map_remove_entry/1),
-      else: cover(:invalid)
+    if Enum.all?(remove, &valid_remove?/1) do
+      Enum.map(remove, &map_remove_entry/1)
+    else
+      cover(:invalid)
+    end
   end
 
   defp valid_remove?(name) when is_list(name), do: cover(true)

--- a/lib/xgit/repository.ex
+++ b/lib/xgit/repository.ex
@@ -195,9 +195,11 @@ defmodule Xgit.Repository do
     do: {:reply, working_tree, state}
 
   def handle_call({:set_default_working_tree, working_tree}, _from, %{working_tree: nil} = state) do
-    if WorkingTree.valid?(working_tree),
-      do: {:reply, :ok, %{state | working_tree: working_tree}},
-      else: {:reply, :error, state}
+    if WorkingTree.valid?(working_tree) do
+      {:reply, :ok, %{state | working_tree: working_tree}}
+    else
+      {:reply, :error, state}
+    end
   end
 
   def handle_call({:set_default_working_tree, _working_tree}, _from, state),

--- a/lib/xgit/util/file_snapshot.ex
+++ b/lib/xgit/util/file_snapshot.ex
@@ -168,9 +168,11 @@ defmodule Xgit.Util.FileSnapshot do
       ) do
     other_last_read = ConCache.get(:xgit_file_snapshot, other_ref)
 
-    if not_racy_clean?(last_modified, other_last_read),
-      do: ConCache.delete(:xgit_file_snapshot, ref),
-      else: record_time_for_ref(ref, not_racy_clean?(last_modified, other_last_read))
+    if not_racy_clean?(last_modified, other_last_read) do
+      ConCache.delete(:xgit_file_snapshot, ref)
+    else
+      record_time_for_ref(ref, not_racy_clean?(last_modified, other_last_read))
+    end
 
     cover :ok
   end


### PR DESCRIPTION
## Changes in This Pull Request
A few `if/do/else` statements were still written using the shorthand named-expressions format. Most got rewritten in #122. Make them all use the same syntax.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- ~All applicable changes have been documented.~ _n/a_
- ~There is test coverage for all changes.~ _n/a_
- ~All cases where a literal value is returned use the `cover` macro to force code coverage.~ _n/a_
- ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_