### PR TITLE
Implement Xgit.Core.FilePath.ensure_trailing_separator/1.

### DIFF
--- a/lib/xgit/core/file_path.ex
+++ b/lib/xgit/core/file_path.ex
@@ -535,6 +535,19 @@ defmodule Xgit.Core.FilePath do
   defp to_lower(b), do: cover(b)
 
   @doc ~S"""
+  Ensure that a trailing `/` is present.
+
+  **Exception:** If the path is empty, it will be returned as-is.
+  """
+  @spec ensure_trailing_separator(path :: t) :: t
+  def ensure_trailing_separator([]), do: cover([])
+
+  def ensure_trailing_separator(path) when is_list(path) do
+    # We strip trailing `/` because there might be more than one.
+    strip_trailing_separator(path) ++ '/'
+  end
+
+  @doc ~S"""
   Remove trailing `/` if present.
   """
   @spec strip_trailing_separator(path :: t) :: t

--- a/test/xgit/core/file_path_test.exs
+++ b/test/xgit/core/file_path_test.exs
@@ -491,6 +491,24 @@ defmodule Xgit.Core.FilePathTest do
     end
   end
 
+  describe "ensure_trailing_separator/1" do
+    test "empty list" do
+      assert ensure_trailing_separator([]) == []
+    end
+
+    test "without trailing /" do
+      assert ensure_trailing_separator('abc') == 'abc/'
+      assert ensure_trailing_separator('/abc') == '/abc/'
+      assert ensure_trailing_separator('foo/b') == 'foo/b/'
+    end
+
+    test "with trailing /" do
+      assert ensure_trailing_separator('/') == '/'
+      assert ensure_trailing_separator('abc/') == 'abc/'
+      assert ensure_trailing_separator('foo/bar//') == 'foo/bar/'
+    end
+  end
+
   describe "strip_trailing_separator/1" do
     test "empty list" do
       assert strip_trailing_separator([]) == []


### PR DESCRIPTION
## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] There is test coverage for all changes.
- [x] All cases where a literal value is returned use the `cover` macro to force code coverage.
- ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
