### PR TITLE
Implement Xgit.Core.FilePath.starts_with?/2.

### DIFF
--- a/lib/xgit/core/file_path.ex
+++ b/lib/xgit/core/file_path.ex
@@ -535,6 +535,18 @@ defmodule Xgit.Core.FilePath do
   defp to_lower(b), do: cover(b)
 
   @doc ~S"""
+  Returns `true` if `path` starts with `prefix`.
+
+  Unlike `String.starts_with?/2`, only accepts a single prefix path.
+  """
+  @spec starts_with?(path :: t, prefix :: t) :: boolean
+  def starts_with?(path, prefix)
+
+  def starts_with?(_path, []), do: cover(true)
+  def starts_with?([c | path], [c | prefix]), do: starts_with?(path, prefix)
+  def starts_with?(_path, _prefix), do: cover(false)
+
+  @doc ~S"""
   Ensure that a trailing `/` is present.
 
   **Exception:** If the path is empty, it will be returned as-is.

--- a/test/xgit/core/file_path_test.exs
+++ b/test/xgit/core/file_path_test.exs
@@ -491,6 +491,17 @@ defmodule Xgit.Core.FilePathTest do
     end
   end
 
+  test "starts_with?/2" do
+    assert starts_with?('', '')
+    assert starts_with?('abc', '')
+    assert starts_with?('abc', 'a')
+    assert starts_with?('abc', 'abc')
+    refute starts_with?('xabc', 'abc')
+    refute starts_with?('abc', 'abd')
+    refute starts_with?('ab', 'abc')
+    refute starts_with?('', 'a')
+  end
+
   describe "ensure_trailing_separator/1" do
     test "empty list" do
       assert ensure_trailing_separator([]) == []


### PR DESCRIPTION
## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] There is test coverage for all changes.
- [x] All cases where a literal value is returned use the `cover` macro to force code coverage.
- ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ -n/a_
- ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
