### PR TITLE
Implement Xgit.Core.Tree struct.

### DIFF
--- a/lib/xgit/core/tree.ex
+++ b/lib/xgit/core/tree.ex
@@ -1,0 +1,116 @@
+defmodule Xgit.Core.Tree do
+  @moduledoc ~S"""
+  Represents a git `tree` object in memory.
+  """
+
+  import Xgit.Util.ForceCoverage
+
+  @typedoc ~S"""
+  This struct describes a single `tree` object so it can be manipulated in memory.
+
+  ## Struct Members
+
+  * `:entries`: list of `Tree.Entry` structs, which must be sorted by name
+  """
+  @type t :: %__MODULE__{entries: [__MODULE__.Entry.t()]}
+
+  @enforce_keys [:entries]
+  defstruct [:entries]
+
+  defmodule Entry do
+    @moduledoc ~S"""
+    A single file in a `tree` structure.
+    """
+
+    use Xgit.Core.FileMode
+
+    alias Xgit.Core.FileMode
+    alias Xgit.Core.FilePath
+    alias Xgit.Core.ObjectId
+    alias Xgit.Util.Comparison
+
+    import Xgit.Util.ForceCoverage
+
+    @typedoc ~S"""
+    A single file in a tree structure.
+
+    ## Struct Members
+
+    * `name`: (`FilePath.t`) entry path name, relative to top-level directory (without leading slash)
+    * `object_id`: (`ObjectId.t`) SHA-1 for the represented object
+    * `mode`: (`FileMode.t`)
+    """
+    @type t :: %__MODULE__{
+            name: FilePath.t(),
+            object_id: ObjectId.t(),
+            mode: FileMode.t()
+          }
+
+    @enforce_keys [:name, :object_id, :mode]
+    defstruct [:name, :object_id, :mode]
+
+    @doc ~S"""
+    Return `true` if this entry struct describes a valid tree entry.
+    """
+    @spec valid?(entry :: any) :: boolean
+    def valid?(entry)
+
+    def valid?(
+          %__MODULE__{
+            name: name,
+            object_id: object_id,
+            mode: mode
+          } = _entry
+        )
+        when is_list(name) and is_binary(object_id) and is_file_mode(mode) do
+      FilePath.check_path_segment(name) == :ok && ObjectId.valid?(object_id) &&
+        object_id != ObjectId.zero()
+    end
+
+    def valid?(_), do: cover(false)
+
+    @doc ~S"""
+    Compare two entries according to git file name sorting rules.
+
+    ## Return Value
+
+    * `:lt` if `entry1` sorts before `entry2`.
+    * `:eq` if they are the same.
+    * `:gt` if `entry1` sorts after `entry2`.
+    """
+    @spec compare(entry1 :: t | nil, entry2 :: t) :: Comparison.result()
+    def compare(entry1, entry2)
+
+    def compare(nil, _entry2), do: cover(:lt)
+
+    def compare(%{name: name1} = _entry1, %{name: name2} = _entry2) do
+      cond do
+        name1 < name2 -> cover :lt
+        name2 < name1 -> cover :gt
+        true -> cover :eq
+      end
+    end
+  end
+
+  @doc ~S"""
+  Return `true` if the value is a tree struct that is valid.
+
+  All of the following must be true for this to occur:
+  * The value is a `Tree` struct.
+  * The entries are properly sorted.
+  * All entries are valid, as determined by `Xgit.Core.Tree.Entry.valid?/1`.
+  """
+  @spec valid?(dir_cache :: any) :: boolean
+  def valid?(dir_cache)
+
+  def valid?(%__MODULE__{entries: entries}) when is_list(entries) do
+    Enum.all?(entries, &Entry.valid?/1) && entries_sorted?([nil | entries])
+  end
+
+  def valid?(_), do: cover(false)
+
+  defp entries_sorted?([entry1, entry2 | tail]),
+    do: Entry.compare(entry1, entry2) == :lt && entries_sorted?([entry2 | tail])
+
+  defp entries_sorted?([_]), do: cover(true)
+end

--- a/test/xgit/core/tree/entry_test.exs
+++ b/test/xgit/core/tree/entry_test.exs
@@ -1,0 +1,61 @@
+defmodule Xgit.Core.Tree.EntryTest do
+  use ExUnit.Case, async: true
+
+  alias Xgit.Core.Tree.Entry
+
+  @valid %Entry{
+    name: 'hello.txt',
+    object_id: "7919e8900c3af541535472aebd56d44222b7b3a3",
+    mode: 0o100644
+  }
+
+  describe "valid?/1" do
+    test "happy path: valid entry" do
+      assert Entry.valid?(@valid)
+    end
+
+    @invalid_mods [
+      name: "binary, not byte list",
+      name: '',
+      name: '/absolute/path',
+      object_id: "7919e8900c3af541535472aebd56d44222b7b3a",
+      object_id: "7919e8900c3af541535472aebd56d44222b7b3a34",
+      object_id: "0000000000000000000000000000000000000000",
+      mode: 0,
+      mode: 0o100645
+    ]
+
+    test "invalid entries" do
+      Enum.each(@invalid_mods, fn {key, value} ->
+        invalid = Map.put(@valid, key, value)
+
+        refute(
+          Entry.valid?(invalid),
+          "incorrectly accepted entry with :#{key} set to #{inspect(value)}"
+        )
+      end)
+    end
+  end
+
+  describe "compare/2" do
+    test "special case: nil sorts first" do
+      assert Entry.compare(nil, @valid) == :lt
+    end
+
+    test "equality" do
+      assert Entry.compare(@valid, @valid) == :eq
+    end
+
+    @name_gt Map.put(@valid, :name, 'later.txt')
+    test "comparison based on name" do
+      assert Entry.compare(@valid, @name_gt) == :lt
+      assert Entry.compare(@name_gt, @valid) == :gt
+    end
+
+    @mode_gt Map.put(@valid, :mode, 0o100755)
+    test "doesn't compare based on mode" do
+      assert Entry.compare(@valid, @mode_gt) == :eq
+      assert Entry.compare(@mode_gt, @valid) == :eq
+    end
+  end
+end

--- a/test/xgit/core/tree_test.exs
+++ b/test/xgit/core/tree_test.exs
@@ -19,6 +19,11 @@ defmodule Xgit.Core.TreeTest do
       assert Tree.valid?(@valid)
     end
 
+    test "not a Tree struct" do
+      refute Tree.valid?(%{})
+      refute Tree.valid?("tree")
+    end
+
     @invalid_mods [
       entries: [Map.put(@valid_entry, :name, "binary not allowed here")],
       entries: [Map.put(@valid_entry, :name, 'no/slashes')],

--- a/test/xgit/core/tree_test.exs
+++ b/test/xgit/core/tree_test.exs
@@ -1,0 +1,59 @@
+defmodule Xgit.Core.TreeTest do
+  use ExUnit.Case, async: true
+
+  alias Xgit.Core.Tree
+  alias Xgit.Core.Tree.Entry
+
+  @valid_entry %Entry{
+    name: 'hello.txt',
+    object_id: "7919e8900c3af541535472aebd56d44222b7b3a3",
+    mode: 0o100644
+  }
+
+  @valid %Tree{
+    entries: [@valid_entry]
+  }
+
+  describe "valid?/1" do
+    test "happy path: valid entry" do
+      assert Tree.valid?(@valid)
+    end
+
+    @invalid_mods [
+      entries: [Map.put(@valid_entry, :name, "binary not allowed here")],
+      entries: [Map.put(@valid_entry, :name, 'no/slashes')],
+      entries: [42]
+    ]
+
+    test "invalid entries" do
+      Enum.each(@invalid_mods, fn {key, value} ->
+        invalid = Map.put(@valid, key, value)
+
+        refute(
+          Tree.valid?(invalid),
+          "incorrectly accepted entry with :#{key} set to #{inspect(value)}"
+        )
+      end)
+    end
+
+    test "sorted (name)" do
+      assert Tree.valid?(%Tree{
+               entries: [
+                 Map.put(@valid_entry, :name, 'abc'),
+                 Map.put(@valid_entry, :name, 'abd'),
+                 Map.put(@valid_entry, :name, 'abe')
+               ]
+             })
+    end
+
+    test "not sorted (name)" do
+      refute Tree.valid?(%Tree{
+               entries: [
+                 Map.put(@valid_entry, :name, 'abc'),
+                 Map.put(@valid_entry, :name, 'abf'),
+                 Map.put(@valid_entry, :name, 'abe')
+               ]
+             })
+    end
+  end
+end


### PR DESCRIPTION
## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] There is test coverage for all changes.
- [x] All cases where a literal value is returned use the `cover` macro to force code coverage.
- ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
