### PR TITLE
Xgit.Core.FileMode: Replace to_octal/1 with to_short_octal/1.

### DIFF
--- a/lib/xgit/core/file_mode.ex
+++ b/lib/xgit/core/file_mode.ex
@@ -89,16 +89,18 @@ defmodule Xgit.Core.FileMode do
   @doc ~S"""
   Return a rendered version of this file mode as an octal charlist.
 
+  No leading zeros are included.
+
   Optimized for the known file modes. Errors out for any other mode.
   """
-  @spec to_octal(file_mode :: t) :: charlist
-  def to_octal(file_mode)
+  @spec to_short_octal(file_mode :: t) :: charlist
+  def to_short_octal(file_mode)
 
-  def to_octal(0o040000), do: cover('040000')
-  def to_octal(0o120000), do: cover('120000')
-  def to_octal(0o100644), do: cover('100644')
-  def to_octal(0o100755), do: cover('100755')
-  def to_octal(0o160000), do: cover('160000')
+  def to_short_octal(0o040000), do: cover('40000')
+  def to_short_octal(0o120000), do: cover('120000')
+  def to_short_octal(0o100644), do: cover('100644')
+  def to_short_octal(0o100755), do: cover('100755')
+  def to_short_octal(0o160000), do: cover('160000')
 
   @doc ~S"""
   This guard requires the value to be one of the known git file mode values.

--- a/lib/xgit/core/tree.ex
+++ b/lib/xgit/core/tree.ex
@@ -139,5 +139,5 @@ defmodule Xgit.Core.Tree do
   end
 
   defp entry_to_iodata(%__MODULE__.Entry{name: name, object_id: object_id, mode: mode}),
-    do: cover([FileMode.to_octal(mode), ?\s, name, 0, ObjectId.to_binary_iodata(object_id)])
+    do: cover([FileMode.to_short_octal(mode), ?\s, name, 0, ObjectId.to_binary_iodata(object_id)])
 end

--- a/test/xgit/core/file_mode_test.exs
+++ b/test/xgit/core/file_mode_test.exs
@@ -65,15 +65,15 @@ defmodule Xgit.Core.FileModeTest do
     refute FileMode.valid?(FileMode.gitlink() + 1)
   end
 
-  test "to_octal/1" do
-    assert FileMode.to_octal(FileMode.tree()) == '040000'
-    assert FileMode.to_octal(FileMode.symlink()) == '120000'
-    assert FileMode.to_octal(FileMode.regular_file()) == '100644'
-    assert FileMode.to_octal(FileMode.executable_file()) == '100755'
-    assert FileMode.to_octal(FileMode.gitlink()) == '160000'
+  test "to_short_octal/1" do
+    assert FileMode.to_short_octal(FileMode.tree()) == '40000'
+    assert FileMode.to_short_octal(FileMode.symlink()) == '120000'
+    assert FileMode.to_short_octal(FileMode.regular_file()) == '100644'
+    assert FileMode.to_short_octal(FileMode.executable_file()) == '100755'
+    assert FileMode.to_short_octal(FileMode.gitlink()) == '160000'
 
     assert_raise FunctionClauseError, fn ->
-      FileMode.to_octal(FileMode.gitlink() + 1)
+      FileMode.to_short_octal(FileMode.gitlink() + 1)
     end
   end
 


### PR DESCRIPTION
## Changes in This Pull Request
This version does not include leading zeros, which is the correct notation for tree structures.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] There is test coverage for all changes.
- [x] All cases where a literal value is returned use the `cover` macro to force code coverage.
- ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
