### PR TITLE
DirCache.valid?/1 should not allow a file and directory to exist at the same prefix.

### DIFF
--- a/lib/xgit/core/dir_cache.ex
+++ b/lib/xgit/core/dir_cache.ex
@@ -259,8 +259,12 @@ defmodule Xgit.Core.DirCache do
 
   def valid?(_), do: cover(false)
 
-  defp entries_sorted?([entry1, entry2 | tail]),
-    do: Entry.compare(entry1, entry2) == :lt && entries_sorted?([entry2 | tail])
+  defp entries_sorted?([entry1, entry2 | tail]) do
+    Entry.compare(entry1, entry2) == :lt &&
+      (entry1 == nil ||
+         not FilePath.starts_with?(entry2.name, FilePath.ensure_trailing_separator(entry1.name))) &&
+      entries_sorted?([entry2 | tail])
+  end
 
   defp entries_sorted?([_]), do: cover(true)
 

--- a/test/xgit/core/dir_cache_test.exs
+++ b/test/xgit/core/dir_cache_test.exs
@@ -82,6 +82,17 @@ defmodule Xgit.Core.DirCacheTest do
              })
     end
 
+    test "file and tree at same prefix" do
+      refute DirCache.valid?(%DirCache{
+               version: 2,
+               entry_count: 2,
+               entries: [
+                 Map.put(@valid_entry, :name, 'a'),
+                 Map.put(@valid_entry, :name, 'a/b')
+               ]
+             })
+    end
+
     test "not sorted (name)" do
       refute DirCache.valid?(%DirCache{
                version: 2,


### PR DESCRIPTION
## Checklist
- [x] This PR represents a single feature, fix, or change.
- ~All applicable changes have been documented.~ _n/a_
- [x] There is test coverage for all changes.
- ~All cases where a literal value is returned use the `cover` macro to force code coverage.~ _n/a_
- ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
