### PR TITLE
Implement Xgit.Repository.has_all_object_ids?/2.

### DIFF
--- a/lib/xgit/repository/in_memory.ex
+++ b/lib/xgit/repository/in_memory.ex
@@ -31,6 +31,12 @@ defmodule Xgit.Repository.InMemory do
   def init(opts) when is_list(opts), do: cover({:ok, %{loose_objects: %{}}})
 
   @impl true
+  def handle_has_all_object_ids?(%{loose_objects: objects} = state, object_ids) do
+    has_all_objects? = Enum.all?(object_ids, fn object_id -> Map.has_key?(objects, object_id) end)
+    cover {:ok, has_all_objects?, state}
+  end
+
+  @impl true
   def handle_get_object(%{loose_objects: objects} = state, object_id) do
     # Currently only checks for loose objects.
     # TO DO: Look for object in packs.

--- a/lib/xgit/repository/on_disk.ex
+++ b/lib/xgit/repository/on_disk.ex
@@ -87,6 +87,10 @@ defmodule Xgit.Repository.OnDisk do
   defdelegate create(work_dir), to: Xgit.Repository.OnDisk.Create
 
   @impl true
+  defdelegate handle_has_all_object_ids?(state, object_ids),
+    to: Xgit.Repository.OnDisk.HasAllObjectIds
+
+  @impl true
   defdelegate handle_get_object(state, object_id),
     to: Xgit.Repository.OnDisk.GetObject
 

--- a/lib/xgit/repository/on_disk/has_all_object_ids.ex
+++ b/lib/xgit/repository/on_disk/has_all_object_ids.ex
@@ -1,0 +1,30 @@
+defmodule Xgit.Repository.OnDisk.HasAllObjectIds do
+  @moduledoc false
+  # Implements Xgit.Repository.OnDisk.handle_has_all_objects?/2.
+
+  import Xgit.Util.ForceCoverage
+
+  alias Xgit.Core.ObjectId
+
+  @spec handle_has_all_object_ids?(state :: any, object_ids :: [ObjectId.t()]) ::
+          {:ok, has_all_object_ids? :: boolean, state :: any}
+          | {:error, reason :: any, state :: any}
+  def handle_has_all_object_ids?(%{git_dir: git_dir} = state, object_ids) do
+    has_all_object_ids? =
+      Enum.all?(object_ids, fn object_id -> has_object_id?(git_dir, object_id) end)
+
+    cover {:ok, has_all_object_ids?, state}
+  end
+
+  defp has_object_id?(git_dir, object_id) do
+    loose_object_path =
+      Path.join([
+        git_dir,
+        "objects",
+        String.slice(object_id, 0, 2),
+        String.slice(object_id, 2, 38)
+      ])
+
+    File.regular?(loose_object_path)
+  end
+end

--- a/test/xgit/repository/in_memory/has_all_object_ids_test.exs
+++ b/test/xgit/repository/in_memory/has_all_object_ids_test.exs
@@ -1,0 +1,60 @@
+defmodule Xgit.Repository.InMemory.HasAllObjectIdsTest do
+  use ExUnit.Case, async: true
+
+  alias Xgit.Core.Object
+  alias Xgit.Repository
+  alias Xgit.Repository.InMemory
+
+  describe "has_all_object_ids?/2" do
+    @test_content 'test content\n'
+    @test_content_id "d670460b4b4aece5915caf5c68d12f560a9fe3e4"
+
+    setup do
+      assert {:ok, repo} = InMemory.start_link()
+
+      object = %Object{type: :blob, content: @test_content, size: 13, id: @test_content_id}
+      assert :ok = Repository.put_loose_object(repo, object)
+
+      # Yes, the hash is wrong, but we'll ignore that for now.
+      object = %Object{
+        type: :blob,
+        content: @test_content,
+        size: 15,
+        id: "c1e116090ad56f172370351ab3f773eb0f1fe89e"
+      }
+
+      assert :ok = Repository.put_loose_object(repo, object)
+
+      {:ok, repo: repo}
+    end
+
+    test "happy path: zero object IDs", %{repo: repo} do
+      assert Repository.has_all_object_ids?(repo, [])
+    end
+
+    test "happy path: one object ID", %{repo: repo} do
+      assert Repository.has_all_object_ids?(repo, [@test_content_id])
+    end
+
+    test "happy path: two object IDs", %{repo: repo} do
+      assert Repository.has_all_object_ids?(repo, [
+               @test_content_id,
+               "c1e116090ad56f172370351ab3f773eb0f1fe89e"
+             ])
+    end
+
+    test "happy path: partial match", %{repo: repo} do
+      refute Repository.has_all_object_ids?(repo, [
+               @test_content_id,
+               "b9e3a9e3ea7dde01d652f899a783b75a1518564c"
+             ])
+    end
+
+    test "happy path: no match", %{repo: repo} do
+      refute Repository.has_all_object_ids?(repo, [
+               @test_content_id,
+               "6ee878a55ed36e2cda2c68452d2336ce3bd692d1"
+             ])
+    end
+  end
+end

--- a/test/xgit/repository/on_disk/has_all_object_ids_test.exs
+++ b/test/xgit/repository/on_disk/has_all_object_ids_test.exs
@@ -1,0 +1,64 @@
+defmodule Xgit.Repository.OnDisk.HasAllObjectIdsTest do
+  use Xgit.GitInitTestCase, async: true
+
+  alias Xgit.Core.Object
+  alias Xgit.Repository
+  alias Xgit.Repository.OnDisk
+
+  describe "has_all_object_ids?/2" do
+    @test_content 'test content\n'
+    @test_content_id "d670460b4b4aece5915caf5c68d12f560a9fe3e4"
+
+    setup %{xgit: xgit} do
+      assert :ok = OnDisk.create(xgit)
+      assert {:ok, repo} = OnDisk.start_link(work_dir: xgit)
+
+      object = %Object{type: :blob, content: @test_content, size: 13, id: @test_content_id}
+      assert :ok = Repository.put_loose_object(repo, object)
+
+      # Yes, the hash is wrong, but we'll ignore that for now.
+      object = %Object{
+        type: :blob,
+        content: @test_content,
+        size: 15,
+        id: "c1e116090ad56f172370351ab3f773eb0f1fe89e"
+      }
+
+      assert :ok = Repository.put_loose_object(repo, object)
+
+      {:ok, repo: repo}
+    end
+
+    test "happy path: zero object IDs", %{repo: repo} do
+      assert true == Repository.has_all_object_ids?(repo, [])
+    end
+
+    test "happy path: one object ID", %{repo: repo} do
+      assert true == Repository.has_all_object_ids?(repo, [@test_content_id])
+    end
+
+    test "happy path: two object IDs", %{repo: repo} do
+      assert true ==
+               Repository.has_all_object_ids?(repo, [
+                 @test_content_id,
+                 "c1e116090ad56f172370351ab3f773eb0f1fe89e"
+               ])
+    end
+
+    test "happy path: partial match", %{repo: repo} do
+      assert false ==
+               Repository.has_all_object_ids?(repo, [
+                 @test_content_id,
+                 "b9e3a9e3ea7dde01d652f899a783b75a1518564c"
+               ])
+    end
+
+    test "happy path: no match", %{repo: repo} do
+      assert false ==
+               Repository.has_all_object_ids?(repo, [
+                 @test_content_id,
+                 "6ee878a55ed36e2cda2c68452d2336ce3bd692d1"
+               ])
+    end
+  end
+end


### PR DESCRIPTION
## Changes in This Pull Request
In the upcoming implementation of `git write-tree`, this will be used to enforce the requirement that all objects referenced in the index are present in the object store.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] There is test coverage for all changes.
- [x] All cases where a literal value is returned use the `cover` macro to force code coverage.
- ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
