### PR TITLE
Implement Xgit.Plumbing.WriteTree.

### DIFF
--- a/lib/xgit/plumbing/write_tree.ex
+++ b/lib/xgit/plumbing/write_tree.ex
@@ -1,0 +1,136 @@
+defmodule Xgit.Plumbing.WriteTree do
+  @moduledoc ~S"""
+  Write the index file as a `tree` object.
+
+  Analogous to
+  [`git write-tree`](https://git-scm.com/docs/git-write-tree).
+  """
+
+  import Xgit.Util.ForceCoverage
+
+  alias Xgit.Core.DirCache
+  alias Xgit.Core.FilePath
+  alias Xgit.Core.Object
+  alias Xgit.Core.ObjectId
+  alias Xgit.Plumbing.Util.WorkingTreeOpt
+  alias Xgit.Repository
+  alias Xgit.Repository.WorkingTree
+  alias Xgit.Repository.WorkingTree.ParseIndexFile
+
+  @typedoc ~S"""
+  Reason codes that can be returned by `run/2`.
+  """
+  @type reason ::
+          :invalid_repository
+          | :bare
+          | :incomplete_merge
+          | :objects_missing
+          | DirCache.to_tree_objects_reason()
+          | ParseIndexFile.from_iodevice_reason()
+          | Repository.put_loose_object_reason()
+
+  @doc ~S"""
+  Retrieves information about files in the working tree as described by the index file.
+
+  The working tree must be in a fully-merged state.
+
+  ## Parameters
+
+  `repository` is the `Xgit.Repository` (PID) to search for the object.
+
+  ## Options
+
+  `:missing_ok?`: `true` to ignore any objects that are referenced by the index
+  file that are not present in the object database. Normally this would be an error.
+
+  `:prefix`: (`Xgit.Core.FilePath`) if present, returns the `object_id` for the tree at
+  the given subdirectory.  If not present, writes a tree corresponding to the root.
+  (The entire tree is written in either case.)
+
+  ## Return Value
+
+  `{:ok, object_id}` with the object ID for the tree that was generated. (If the exact tree
+  specified by the index already existed, it will return that existing tree's ID.)
+
+  `{:error, :invalid_repository}` if `repository` doesn't represent a valid
+  `Xgit.Repository` process.
+
+  `{:error, :bare}` if `repository` doesn't have a working tree.
+
+  `{:error, :incomplete_merge}` if any entry in the index file is not fully merged.
+
+  `{:error, :objects_missing}` if any of the objects referenced by the index
+  are not present in the object store. (Exception: If `missing_ok?` is `true`,
+  then this condition will be ignored.)
+
+  Reason codes may also come from the following functions:
+
+  * `Xgit.Core.DirCache.to_tree_objects/2`
+  * `Xgit.Repository.put_loose_object/2`
+  * `Xgit.Repository.WorkingTree.ParseIndexFile.from_iodevice/1`
+  """
+  @spec run(repository :: Repository.t()) ::
+          {:ok, object_id :: ObjectId.t()}
+          | {:error, reason :: reason}
+  def run(repository, opts \\ []) when is_pid(repository) do
+    with {:ok, working_tree} <- WorkingTreeOpt.get(repository),
+         {missing_ok?, prefix} <- validate_options(opts),
+         {:ok, %DirCache{entries: entries} = dir_cache} <- WorkingTree.dir_cache(working_tree),
+         {:merged?, true} <- {:merged?, DirCache.fully_merged?(dir_cache)},
+         {:has_all_objects?, true} <-
+           {:has_all_objects?, has_all_objects?(repository, entries, missing_ok?)},
+         {:ok, objects, %Object{id: object_id}} <- DirCache.to_tree_objects(dir_cache, prefix),
+         :ok <- write_all_objects(repository, objects) do
+      cover {:ok, object_id}
+    else
+      {:error, reason} -> cover {:error, reason}
+      {:merged?, false} -> cover {:error, :incomplete_merge}
+      {:has_all_objects?, false} -> cover {:error, :objects_missing}
+    end
+  end
+
+  defp validate_options(opts) do
+    missing_ok? = Keyword.get(opts, :missing_ok?, false)
+
+    unless is_boolean(missing_ok?) do
+      raise ArgumentError,
+            "Xgit.Plumbing.WriteTree.run/2: missing_ok? #{inspect(missing_ok?)} is invalid"
+    end
+
+    prefix = Keyword.get(opts, :prefix, [])
+
+    unless prefix == [] or FilePath.valid?(prefix) do
+      raise ArgumentError,
+            "Xgit.Plumbing.WriteTree.run/2: prefix #{inspect(prefix)} is invalid (should be a charlist, not a String)"
+    end
+
+    {missing_ok?, prefix}
+  end
+
+  defp has_all_objects?(repository, entries, missing_ok?)
+
+  defp has_all_objects?(_repository, _entries, true), do: cover(true)
+
+  defp has_all_objects?(repository, entries, false) do
+    entries
+    |> Enum.chunk_every(100)
+    |> Enum.all?(fn entries_chunk ->
+      Repository.has_all_object_ids?(
+        repository,
+        Enum.map(entries_chunk, fn %{object_id: id} -> id end)
+      )
+    end)
+  end
+
+  defp write_all_objects(repository, objects)
+
+  defp write_all_objects(_repository, []), do: :ok
+
+  defp write_all_objects(repository, [object | tail]) do
+    case Repository.put_loose_object(repository, object) do
+      :ok -> write_all_objects(repository, tail)
+      {:error, :object_exists} -> write_all_objects(repository, tail)
+      {:error, reason} -> {:error, reason}
+    end
+  end
+end

--- a/lib/xgit/plumbing/write_tree.ex
+++ b/lib/xgit/plumbing/write_tree.ex
@@ -30,7 +30,8 @@ defmodule Xgit.Plumbing.WriteTree do
           | Repository.put_loose_object_reason()
 
   @doc ~S"""
-  Retrieves information about files in the working tree as described by the index file.
+  Translates the current working tree, as reflected in its index file, to one or more
+  tree objects.
 
   The working tree must be in a fully-merged state.
 
@@ -44,7 +45,7 @@ defmodule Xgit.Plumbing.WriteTree do
   file that are not present in the object database. Normally this would be an error.
 
   `:prefix`: (`Xgit.Core.FilePath`) if present, returns the `object_id` for the tree at
-  the given subdirectory.  If not present, writes a tree corresponding to the root.
+  the given subdirectory. If not present, writes a tree corresponding to the root.
   (The entire tree is written in either case.)
 
   ## Return Value

--- a/lib/xgit/plumbing/write_tree.ex
+++ b/lib/xgit/plumbing/write_tree.ex
@@ -69,7 +69,7 @@ defmodule Xgit.Plumbing.WriteTree do
   * `Xgit.Repository.put_loose_object/2`
   * `Xgit.Repository.WorkingTree.ParseIndexFile.from_iodevice/1`
   """
-  @spec run(repository :: Repository.t()) ::
+  @spec run(repository :: Repository.t(), missing_ok?: boolean, prefix: FilePath.t()) ::
           {:ok, object_id :: ObjectId.t()}
           | {:error, reason :: reason}
   def run(repository, opts \\ []) when is_pid(repository) do

--- a/test/xgit/plumbing/write_tree_test.exs
+++ b/test/xgit/plumbing/write_tree_test.exs
@@ -1,7 +1,6 @@
 defmodule Xgit.Plumbing.WriteTreeTest do
   use Xgit.GitInitTestCase, async: true
 
-  alias Xgit.Core.DirCache
   alias Xgit.Core.DirCache.Entry
   alias Xgit.GitInitTestCase
   alias Xgit.Plumbing.HashObject

--- a/test/xgit/plumbing/write_tree_test.exs
+++ b/test/xgit/plumbing/write_tree_test.exs
@@ -1,0 +1,386 @@
+defmodule Xgit.Plumbing.WriteTreeTest do
+  use Xgit.GitInitTestCase, async: true
+
+  # alias Xgit.Core.DirCache
+  # alias Xgit.Core.DirCache.Entry
+  alias Xgit.GitInitTestCase
+  alias Xgit.Plumbing.UpdateIndex.CacheInfo
+  alias Xgit.Plumbing.WriteTree
+  # alias Xgit.Repository
+  alias Xgit.Repository.OnDisk
+
+  import FolderDiff
+
+  describe "to_tree_objects/2" do
+    test "happy path: empty dir cache" do
+      assert_same_output(fn _git_dir -> nil end, fn _xgit_repo -> nil end)
+    end
+
+    test "happy path: one root-level entry in dir cache" do
+      assert_same_output(
+        fn git_dir ->
+          {_output, 0} =
+            System.cmd(
+              "git",
+              [
+                "update-index",
+                "--add",
+                "--cacheinfo",
+                "100644",
+                "7919e8900c3af541535472aebd56d44222b7b3a3",
+                "hello.txt"
+              ],
+              cd: git_dir
+            )
+        end,
+        fn xgit_repo ->
+          assert :ok =
+                   CacheInfo.run(
+                     xgit_repo,
+                     [{0o100644, "7919e8900c3af541535472aebd56d44222b7b3a3", 'hello.txt'}]
+                   )
+        end,
+        missing_ok?: true
+      )
+    end
+
+    test "happy path: one blob nested one level" do
+      assert_same_output(
+        fn git_dir ->
+          {_output, 0} =
+            System.cmd(
+              "git",
+              [
+                "update-index",
+                "--add",
+                "--cacheinfo",
+                "100644",
+                "7fa62716fc68733db4c769fe678295cf4cf5b336",
+                "a/b"
+              ],
+              cd: git_dir
+            )
+        end,
+        fn xgit_repo ->
+          assert :ok =
+                   CacheInfo.run(
+                     xgit_repo,
+                     [{0o100644, "7fa62716fc68733db4c769fe678295cf4cf5b336", 'a/b'}]
+                   )
+        end,
+        missing_ok?: true
+      )
+    end
+
+    test "happy path: deeply nested dir cache" do
+      assert_same_output(
+        fn git_dir ->
+          {_output, 0} =
+            System.cmd(
+              "git",
+              [
+                "update-index",
+                "--add",
+                "--cacheinfo",
+                "100644",
+                "7fa62716fc68733db4c769fe678295cf4cf5b336",
+                "a/a/b"
+              ],
+              cd: git_dir
+            )
+
+          {_output, 0} =
+            System.cmd(
+              "git",
+              [
+                "update-index",
+                "--add",
+                "--cacheinfo",
+                "100644",
+                "0f717230e297de82d0f8d761143dc1e1145c6bd5",
+                "a/b/c"
+              ],
+              cd: git_dir
+            )
+
+          {_output, 0} =
+            System.cmd(
+              "git",
+              [
+                "update-index",
+                "--add",
+                "--cacheinfo",
+                "100644",
+                "ff287368514462578ba6406d366113953539cbf1",
+                "a/b/d"
+              ],
+              cd: git_dir
+            )
+
+          {_output, 0} =
+            System.cmd(
+              "git",
+              [
+                "update-index",
+                "--add",
+                "--cacheinfo",
+                "100644",
+                "de588889c4d62aaf3ef3bd90be38fa239be2f5d1",
+                "a/c/x"
+              ],
+              cd: git_dir
+            )
+
+          {_output, 0} =
+            System.cmd(
+              "git",
+              [
+                "update-index",
+                "--add",
+                "--cacheinfo",
+                "100755",
+                "7919e8900c3af541535472aebd56d44222b7b3a3",
+                "other.txt"
+              ],
+              cd: git_dir
+            )
+        end,
+        fn xgit_repo ->
+          assert :ok =
+                   CacheInfo.run(
+                     xgit_repo,
+                     [{0o100644, "7fa62716fc68733db4c769fe678295cf4cf5b336", 'a/a/b'}]
+                   )
+
+          assert :ok =
+                   CacheInfo.run(
+                     xgit_repo,
+                     [{0o100644, "0f717230e297de82d0f8d761143dc1e1145c6bd5", 'a/b/c'}]
+                   )
+
+          assert :ok =
+                   CacheInfo.run(
+                     xgit_repo,
+                     [{0o100644, "ff287368514462578ba6406d366113953539cbf1", 'a/b/d'}]
+                   )
+
+          assert :ok =
+                   CacheInfo.run(
+                     xgit_repo,
+                     [{0o100644, "de588889c4d62aaf3ef3bd90be38fa239be2f5d1", 'a/c/x'}]
+                   )
+
+          assert :ok =
+                   CacheInfo.run(
+                     xgit_repo,
+                     [{0o100755, "7919e8900c3af541535472aebd56d44222b7b3a3", 'other.txt'}]
+                   )
+        end,
+        missing_ok?: true
+      )
+    end
+
+    test "honors prefix" do
+      assert_same_output(
+        fn git_dir ->
+          {_output, 0} =
+            System.cmd(
+              "git",
+              [
+                "update-index",
+                "--add",
+                "--cacheinfo",
+                "100644",
+                "7fa62716fc68733db4c769fe678295cf4cf5b336",
+                "a/a/b"
+              ],
+              cd: git_dir
+            )
+
+          {_output, 0} =
+            System.cmd(
+              "git",
+              [
+                "update-index",
+                "--add",
+                "--cacheinfo",
+                "100644",
+                "0f717230e297de82d0f8d761143dc1e1145c6bd5",
+                "a/b/c"
+              ],
+              cd: git_dir
+            )
+
+          {_output, 0} =
+            System.cmd(
+              "git",
+              [
+                "update-index",
+                "--add",
+                "--cacheinfo",
+                "100644",
+                "ff287368514462578ba6406d366113953539cbf1",
+                "a/b/d"
+              ],
+              cd: git_dir
+            )
+
+          {_output, 0} =
+            System.cmd(
+              "git",
+              [
+                "update-index",
+                "--add",
+                "--cacheinfo",
+                "100644",
+                "de588889c4d62aaf3ef3bd90be38fa239be2f5d1",
+                "a/c/x"
+              ],
+              cd: git_dir
+            )
+
+          {_output, 0} =
+            System.cmd(
+              "git",
+              [
+                "update-index",
+                "--add",
+                "--cacheinfo",
+                "100755",
+                "7919e8900c3af541535472aebd56d44222b7b3a3",
+                "other.txt"
+              ],
+              cd: git_dir
+            )
+        end,
+        fn xgit_repo ->
+          assert :ok =
+                   CacheInfo.run(
+                     xgit_repo,
+                     [{0o100644, "7fa62716fc68733db4c769fe678295cf4cf5b336", 'a/a/b'}]
+                   )
+
+          assert :ok =
+                   CacheInfo.run(
+                     xgit_repo,
+                     [{0o100644, "0f717230e297de82d0f8d761143dc1e1145c6bd5", 'a/b/c'}]
+                   )
+
+          assert :ok =
+                   CacheInfo.run(
+                     xgit_repo,
+                     [{0o100644, "ff287368514462578ba6406d366113953539cbf1", 'a/b/d'}]
+                   )
+
+          assert :ok =
+                   CacheInfo.run(
+                     xgit_repo,
+                     [{0o100644, "de588889c4d62aaf3ef3bd90be38fa239be2f5d1", 'a/c/x'}]
+                   )
+
+          assert :ok =
+                   CacheInfo.run(
+                     xgit_repo,
+                     [{0o100755, "7919e8900c3af541535472aebd56d44222b7b3a3", 'other.txt'}]
+                   )
+        end,
+        missing_ok?: true,
+        prefix: 'a/b'
+      )
+    end
+
+    # test "missing_ok?: false happy path"
+
+    # test "missing_ok? error"
+
+    test "prefix doesn't exist" do
+      {:ok, xgit: xgit} = GitInitTestCase.setup_git_repo()
+
+      :ok = OnDisk.create(xgit)
+      {:ok, repo} = OnDisk.start_link(work_dir: xgit)
+
+      :ok =
+        CacheInfo.run(
+          repo,
+          [{0o100644, "7fa62716fc68733db4c769fe678295cf4cf5b336", 'a/a/b'}]
+        )
+
+      :ok =
+        CacheInfo.run(
+          repo,
+          [{0o100644, "0f717230e297de82d0f8d761143dc1e1145c6bd5", 'a/b/c'}]
+        )
+
+      :ok =
+        CacheInfo.run(
+          repo,
+          [{0o100644, "ff287368514462578ba6406d366113953539cbf1", 'a/b/d'}]
+        )
+
+      :ok =
+        CacheInfo.run(
+          repo,
+          [{0o100644, "de588889c4d62aaf3ef3bd90be38fa239be2f5d1", 'a/c/x'}]
+        )
+
+      :ok =
+        CacheInfo.run(
+          repo,
+          [{0o100755, "7919e8900c3af541535472aebd56d44222b7b3a3", 'other.txt'}]
+        )
+
+      assert {:error, :prefix_not_found} =
+               WriteTree.run(repo, missing_ok?: true, prefix: 'no/such/prefix')
+    end
+
+    # test "error: invalid dir cache" do
+    #   assert {:error, :invalid_dir_cache} =
+    #            DirCache.to_tree_objects(%DirCache{
+    #              version: 2,
+    #              entry_count: 3,
+    #              entries: [
+    #                Map.put(@valid_entry, :name, 'abc'),
+    #                Map.put(@valid_entry, :name, 'abf'),
+    #                Map.put(@valid_entry, :name, 'abe')
+    #              ]
+    #            })
+    # end
+
+    defp assert_same_output(git_ref_fn, xgit_fn, opts \\ []) do
+      {:ok, ref: ref, xgit: xgit} = GitInitTestCase.setup_git_repo()
+
+      missing_ok? = Keyword.get(opts, :missing_ok?, false)
+      prefix = Keyword.get(opts, :prefix, [])
+
+      git_ref_fn.(ref)
+
+      git_opts =
+        ["write-tree"]
+        |> maybe_add_missing_ok?(missing_ok?)
+        |> maybe_add_prefix(prefix)
+
+      {output, 0} = System.cmd("git", git_opts, cd: ref)
+      git_ref_object_id = String.trim(output)
+
+      :ok = OnDisk.create(xgit)
+      {:ok, repo} = OnDisk.start_link(work_dir: xgit)
+
+      xgit_fn.(repo)
+
+      assert {:ok, xgit_object_id} = WriteTree.run(repo, opts)
+
+      assert_folders_are_equal(
+        Path.join([ref, ".git", "objects"]),
+        Path.join([xgit, ".git", "objects"])
+      )
+
+      assert git_ref_object_id == xgit_object_id
+    end
+
+    defp maybe_add_missing_ok?(git_opts, false), do: git_opts
+    defp maybe_add_missing_ok?(git_opts, true), do: git_opts ++ ["--missing-ok"]
+
+    defp maybe_add_prefix(git_opts, []), do: git_opts
+    defp maybe_add_prefix(git_opts, prefix), do: git_opts ++ ["--prefix=#{prefix}"]
+  end
+end


### PR DESCRIPTION
## Changes in This Pull Request
This is the API equivalent of `git write-tree`.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [ ] There is test coverage for all changes. _still working on that …_
- [x] All cases where a literal value is returned use the `cover` macro to force code coverage.
- ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
