### PR TITLE
Object.valid?/1: Require that content has an implementation for ContentSource protocol.

### DIFF
--- a/lib/xgit/core/object.ex
+++ b/lib/xgit/core/object.ex
@@ -96,7 +96,7 @@ defmodule Xgit.Core.Object do
 
   def valid?(%__MODULE__{type: type, content: content, size: size, id: id})
       when is_object_type(type) and is_integer(size) and size >= 0,
-      do: ObjectId.valid?(id) && content != nil
+      do: ObjectId.valid?(id) && content != nil && ContentSource.impl_for(content) != nil
 
   def valid?(_), do: cover(false)
 

--- a/test/xgit/core/object_test.exs
+++ b/test/xgit/core/object_test.exs
@@ -48,6 +48,7 @@
 defmodule Xgit.Core.ObjectTest do
   use ExUnit.Case, async: true
 
+  alias Xgit.Core.FileContentSource
   alias Xgit.Core.Object
 
   import Xgit.Core.Object, only: [check: 1, check: 2]
@@ -112,6 +113,31 @@ defmodule Xgit.Core.ObjectTest do
       for id <- @invalid_object_ids do
         refute Object.valid?(%Object{type: :blob, content: [], size: 0, id: id})
       end
+    end
+
+    test "accepts content with a FileContentSource" do
+      Temp.track!()
+      t = Temp.mkdir!()
+      path = Path.join(t, "example")
+      File.write!(path, "example")
+
+      fcs = FileContentSource.new(path)
+
+      assert Object.valid?(%Object{
+               type: :blob,
+               content: fcs,
+               size: 0,
+               id: "cfe0d2db02d583680f90301ff76e0791d9353335"
+             })
+    end
+
+    test "rejects content that isn't a ContentSource" do
+      refute Object.valid?(%Object{
+               type: :blob,
+               content: 42,
+               size: 0,
+               id: "cfe0d2db02d583680f90301ff76e0791d9353335"
+             })
     end
   end
 


### PR DESCRIPTION
## Changes in This Pull Request
I thought there was a case where that didn't happen, but I didn't find it. Nonetheless, a good check to have in place.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- ~All applicable changes have been documented.~ _n/a_
- [x] There is test coverage for all changes.
- ~All cases where a literal value is returned use the `cover` macro to force code coverage.~ _n/a_
- ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_