### PR TITLE
[BUG FIX] OnDisk's implementation of get_object/2 didn't contain a valid ContentSource.

### DIFF
--- a/test/xgit/plumbing/cat_file_test.exs
+++ b/test/xgit/plumbing/cat_file_test.exs
@@ -1,6 +1,7 @@
 defmodule Xgit.Plumbing.CatFileTest do
   use Xgit.GitInitTestCase, async: true
 
+  alias Xgit.Core.ContentSource
   alias Xgit.Plumbing.CatFile
   alias Xgit.Plumbing.HashObject
   alias Xgit.Repository.OnDisk
@@ -19,7 +20,12 @@ defmodule Xgit.Plumbing.CatFileTest do
       assert {:ok, %{type: :blob, size: 13, content: test_content} = object} =
                CatFile.run(repo, test_content_id)
 
-      assert Enum.to_list(test_content) == 'test content\n'
+      rendered_content =
+        test_content
+        |> ContentSource.stream()
+        |> Enum.to_list()
+
+      assert rendered_content == 'test content\n'
     end
 
     test "happy path: can read back from Xgit-written loose object", %{xgit: xgit} do
@@ -31,7 +37,12 @@ defmodule Xgit.Plumbing.CatFileTest do
       assert {:ok, %{type: :blob, size: 13, content: test_content} = object} =
                CatFile.run(repo, test_content_id)
 
-      assert Enum.to_list(test_content) == 'test content\n'
+      rendered_content =
+        test_content
+        |> ContentSource.stream()
+        |> Enum.to_list()
+
+      assert rendered_content == 'test content\n'
     end
 
     test "error: not_found", %{xgit: xgit} do

--- a/test/xgit/repository/in_memory/put_loose_object_test.exs
+++ b/test/xgit/repository/in_memory/put_loose_object_test.exs
@@ -50,6 +50,8 @@ defmodule Xgit.Repository.InMemory.PutLooseObjectTest do
                 size: ^content_size,
                 id: ^content_id
               }} = Repository.get_object(repo, content_id)
+
+      assert Object.valid?(object)
     end
 
     test "error: object exists already" do
@@ -61,6 +63,7 @@ defmodule Xgit.Repository.InMemory.PutLooseObjectTest do
       assert {:error, :object_exists} = Repository.put_loose_object(repo, object)
 
       assert {:ok, ^object} = Repository.get_object(repo, @test_content_id)
+      assert Object.valid?(object)
     end
   end
 end

--- a/test/xgit/repository/on_disk/get_object_test.exs
+++ b/test/xgit/repository/on_disk/get_object_test.exs
@@ -27,6 +27,7 @@ defmodule Xgit.Repository.OnDisk.GetObjectTest do
         |> Enum.to_list()
 
       assert rendered_content == 'test content\n'
+      assert ContentSource.length(test_content) == 13
     end
 
     test "happy path: can read from command-line git (large file)", %{ref: ref} do

--- a/test/xgit/repository/on_disk/get_object_test.exs
+++ b/test/xgit/repository/on_disk/get_object_test.exs
@@ -1,6 +1,7 @@
 defmodule Xgit.Repository.OnDisk.GetObjectTest do
   use Xgit.GitInitTestCase, async: true
 
+  alias Xgit.Core.ContentSource
   alias Xgit.Core.Object
   alias Xgit.Repository
   alias Xgit.Repository.OnDisk
@@ -20,7 +21,12 @@ defmodule Xgit.Repository.OnDisk.GetObjectTest do
               %Object{type: :blob, content: test_content, size: 13, id: ^test_content_id} = object} =
                Repository.get_object(repo, test_content_id)
 
-      assert Enum.to_list(test_content) == 'test content\n'
+      rendered_content =
+        test_content
+        |> ContentSource.stream()
+        |> Enum.to_list()
+
+      assert rendered_content == 'test content\n'
     end
 
     test "happy path: can read from command-line git (large file)", %{ref: ref} do
@@ -43,8 +49,11 @@ defmodule Xgit.Repository.OnDisk.GetObjectTest do
               %Object{type: :blob, content: test_content, size: 6000, id: ^content_id} = object} =
                Repository.get_object(repo, content_id)
 
+      assert Object.valid?(object)
+
       test_content_str =
         test_content
+        |> ContentSource.stream()
         |> Enum.to_list()
         |> to_string()
 

--- a/test/xgit/repository/on_disk/put_loose_object_test.exs
+++ b/test/xgit/repository/on_disk/put_loose_object_test.exs
@@ -28,6 +28,19 @@ defmodule Xgit.Repository.OnDisk.PutLooseObjectTest do
       assert :ok = Repository.put_loose_object(repo, object)
 
       assert_folders_are_equal(ref, xgit)
+
+      assert {:ok,
+              %Object{type: :blob, content: content_read_back, size: 13, id: @test_content_id} =
+                object2} = Repository.get_object(repo, @test_content_id)
+
+      assert Object.valid?(object2)
+
+      content2 =
+        content_read_back
+        |> ContentSource.stream()
+        |> Enum.to_list()
+
+      assert content2 == @test_content
     end
 
     test "happy path matches command-line git (large file)", %{ref: ref, xgit: xgit} do


### PR DESCRIPTION
## Checklist
- [x] This PR represents a single feature, fix, or change.
- ~All applicable changes have been documented.~ _n/a_
- [x] There is test coverage for all changes.
- ~All cases where a literal value is returned use the `cover` macro to force code coverage.~ _n/a_
- ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
