### PR TITLE
Implement Xgit.Core.ObjectId.from_raw_object_id/1.

### DIFF
--- a/lib/xgit/core/object_id.ex
+++ b/lib/xgit/core/object_id.ex
@@ -38,15 +38,19 @@ defmodule Xgit.Core.ObjectId do
 
   `raw_object_id` should be either a binary or list containing a raw object ID (not
   hex-encoded). It should be exactly 20 bytes.
+
+  ## Return Value
+
+  The object ID rendered as lowercase hex. (See `Xgit.Core.ObjectId`.)
   """
-  @spec from_raw_object_id(b :: [byte] | binary) :: t
-  def from_raw_object_id(b) when is_list(b) do
+  @spec from_binary_iodata(b :: iodata) :: t
+  def from_binary_iodata(b) when is_list(b) do
     b
-    |> :binary.list_to_bin()
-    |> from_raw_object_id()
+    |> IO.iodata_to_binary()
+    |> from_binary_iodata()
   end
 
-  def from_raw_object_id(b) when is_binary(b) and byte_size(b) == 20,
+  def from_binary_iodata(b) when is_binary(b) and byte_size(b) == 20,
     do: Base.encode16(b, case: :lower)
 
   @doc ~S"""
@@ -108,7 +112,7 @@ defmodule Xgit.Core.ObjectId do
     |> :crypto.hash_update([0])
     |> hash_update(ContentSource.stream(data))
     |> :crypto.hash_final()
-    |> from_raw_object_id()
+    |> from_binary_iodata()
   end
 
   defp hash_update(crypto_state, data) when is_list(data),

--- a/lib/xgit/core/object_id.ex
+++ b/lib/xgit/core/object_id.ex
@@ -32,6 +32,24 @@ defmodule Xgit.Core.ObjectId do
   def valid?(_), do: cover(false)
 
   @doc ~S"""
+  Read an object ID from raw binary or bytelist.
+
+  ## Parameters
+
+  `raw_object_id` should be either a binary or list containing a raw object ID (not
+  hex-encoded). It should be exactly 20 bytes.
+  """
+  @spec from_raw_object_id(b :: [byte] | binary) :: t
+  def from_raw_object_id(b) when is_list(b) do
+    b
+    |> :binary.list_to_bin()
+    |> from_raw_object_id()
+  end
+
+  def from_raw_object_id(b) when is_binary(b) and byte_size(b) == 20,
+    do: Base.encode16(b, case: :lower)
+
+  @doc ~S"""
   Read an object ID from a hex string (charlist).
 
   ## Return Value
@@ -90,8 +108,7 @@ defmodule Xgit.Core.ObjectId do
     |> :crypto.hash_update([0])
     |> hash_update(ContentSource.stream(data))
     |> :crypto.hash_final()
-    |> Base.encode16()
-    |> String.downcase()
+    |> from_raw_object_id()
   end
 
   defp hash_update(crypto_state, data) when is_list(data),

--- a/lib/xgit/repository/working_tree/parse_index_file.ex
+++ b/lib/xgit/repository/working_tree/parse_index_file.ex
@@ -182,7 +182,7 @@ defmodule Xgit.Repository.WorkingTree.ParseIndexFile do
 
   defp read_object_id(iodevice) do
     case IO.binread(iodevice, 20) do
-      x when is_binary(x) and byte_size(x) == 20 -> ObjectId.from_raw_object_id(x)
+      x when is_binary(x) and byte_size(x) == 20 -> ObjectId.from_binary_iodata(x)
       _ -> cover :invalid
     end
   end

--- a/lib/xgit/repository/working_tree/parse_index_file.ex
+++ b/lib/xgit/repository/working_tree/parse_index_file.ex
@@ -11,6 +11,7 @@ defmodule Xgit.Repository.WorkingTree.ParseIndexFile do
 
   alias Xgit.Core.DirCache
   alias Xgit.Core.DirCache.Entry, as: DirCacheEntry
+  alias Xgit.Core.ObjectId
   alias Xgit.Util.NB
   alias Xgit.Util.TrailingHashDevice
 
@@ -181,13 +182,8 @@ defmodule Xgit.Repository.WorkingTree.ParseIndexFile do
 
   defp read_object_id(iodevice) do
     case IO.binread(iodevice, 20) do
-      x when is_binary(x) and byte_size(x) == 20 ->
-        x
-        |> Base.encode16()
-        |> String.downcase()
-
-      _ ->
-        cover :invalid
+      x when is_binary(x) and byte_size(x) == 20 -> ObjectId.from_raw_object_id(x)
+      _ -> cover :invalid
     end
   end
 

--- a/test/xgit/core/object_id_test.exs
+++ b/test/xgit/core/object_id_test.exs
@@ -22,6 +22,62 @@ defmodule Xgit.Core.ObjectIdTest do
     refute ObjectId.valid?(nil)
   end
 
+  test "from_binary_iodata/1" do
+    assert ObjectId.from_binary_iodata(
+             <<18, 52, 86, 120, 144, 171, 205, 239, 18, 52, 18, 52, 86, 120, 144, 171, 205, 239,
+               18, 52>>
+           ) == "1234567890abcdef12341234567890abcdef1234"
+
+    assert ObjectId.from_binary_iodata([
+             18,
+             52,
+             86,
+             120,
+             144,
+             171,
+             205,
+             239,
+             18,
+             52,
+             18,
+             52,
+             86,
+             120,
+             144,
+             171,
+             205,
+             239,
+             18,
+             52
+           ]) == "1234567890abcdef12341234567890abcdef1234"
+
+    assert_raise FunctionClauseError, fn ->
+      ObjectId.from_binary_iodata([
+        52,
+        86,
+        120,
+        144,
+        171,
+        205,
+        239,
+        18,
+        52,
+        18,
+        52,
+        86,
+        120,
+        144,
+        171,
+        205,
+        239,
+        18,
+        52
+      ])
+
+      # 19 bytes, not 20
+    end
+  end
+
   test "from_hex_charlist/1" do
     assert ObjectId.from_hex_charlist('1234567890abcdef12341234567890abcdef1234') ==
              {"1234567890abcdef12341234567890abcdef1234", []}


### PR DESCRIPTION
## Changes in This Pull Request
Unify production of an `ObjectId` value from raw byte list or binary.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] There is test coverage for all changes.
- [x] All cases where a literal value is returned use the `cover` macro to force code coverage.
- ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
