### PR TITLE
Implement Xgit.Core.Tree.from_object/1.

### DIFF
--- a/test/xgit/core/tree_test.exs
+++ b/test/xgit/core/tree_test.exs
@@ -173,6 +173,17 @@ defmodule Xgit.Core.TreeTest do
       assert {:error, :not_a_tree} = Tree.from_object(object)
     end
 
+    test "object is an invalid tree (ends after file mode)" do
+      object = %Object{
+        type: :tree,
+        size: 42,
+        id: "d670460b4b4aece5915caf5c68d12f560a9fe3e4",
+        content: '100644'
+      }
+
+      assert {:error, :invalid_format} = Tree.from_object(object)
+    end
+
     test "object is an invalid tree (invalid file mode)" do
       object = %Object{
         type: :tree,

--- a/test/xgit/core/tree_test.exs
+++ b/test/xgit/core/tree_test.exs
@@ -202,10 +202,10 @@ defmodule Xgit.Core.TreeTest do
         id: "d670460b4b4aece5915caf5c68d12f560a9fe3e4",
         content:
           '100644 B' ++
-            Enum.map(0..19, fn x -> x end) ++ '100644 A' ++ Enum.map(0..19, fn x -> x end)
+            Enum.map(0..20, fn x -> x end) ++ '100644 A' ++ Enum.map(0..20, fn x -> x end)
       }
 
-      assert {:error, :invalid_format} = Tree.from_object(object)
+      assert {:error, :invalid_tree} = Tree.from_object(object)
     end
 
     test "object is a badly-formatted tree" do

--- a/test/xgit/core/tree_test.exs
+++ b/test/xgit/core/tree_test.exs
@@ -195,6 +195,17 @@ defmodule Xgit.Core.TreeTest do
       assert {:error, :invalid_format} = Tree.from_object(object)
     end
 
+    test "object is an invalid tree (invalid file mode, leading 0)" do
+      object = %Object{
+        type: :tree,
+        size: 42,
+        id: "d670460b4b4aece5915caf5c68d12f560a9fe3e4",
+        content: '0100644 A 12345678901234567890'
+      }
+
+      assert {:error, :invalid_format} = Tree.from_object(object)
+    end
+
     test "object is an invalid tree (not properly sorted)" do
       object = %Object{
         type: :tree,

--- a/test/xgit/core/tree_test.exs
+++ b/test/xgit/core/tree_test.exs
@@ -173,6 +173,17 @@ defmodule Xgit.Core.TreeTest do
       assert {:error, :not_a_tree} = Tree.from_object(object)
     end
 
+    test "object is an invalid tree (invalid file mode)" do
+      object = %Object{
+        type: :tree,
+        size: 42,
+        id: "d670460b4b4aece5915caf5c68d12f560a9fe3e4",
+        content: '100648 A 12345678901234567890'
+      }
+
+      assert {:error, :invalid_format} = Tree.from_object(object)
+    end
+
     test "object is an invalid tree (not properly sorted)" do
       object = %Object{
         type: :tree,

--- a/test/xgit/core/tree_test.exs
+++ b/test/xgit/core/tree_test.exs
@@ -172,6 +172,30 @@ defmodule Xgit.Core.TreeTest do
 
       assert {:error, :not_a_tree} = Tree.from_object(object)
     end
+
+    test "object is an invalid tree (not properly sorted)" do
+      object = %Object{
+        type: :tree,
+        size: 42,
+        id: "d670460b4b4aece5915caf5c68d12f560a9fe3e4",
+        content:
+          '100644 B' ++
+            Enum.map(0..19, fn x -> x end) ++ '100644 A' ++ Enum.map(0..19, fn x -> x end)
+      }
+
+      assert {:error, :invalid_format} = Tree.from_object(object)
+    end
+
+    test "object is a badly-formatted tree" do
+      object = %Object{
+        type: :tree,
+        size: 42,
+        id: "d670460b4b4aece5915caf5c68d12f560a9fe3e4",
+        content: '100644 A' ++ Enum.map(0..20, fn _ -> 0 end)
+      }
+
+      assert {:error, :invalid_format} = Tree.from_object(object)
+    end
   end
 
   describe "to_object/1" do

--- a/test/xgit/core/tree_test.exs
+++ b/test/xgit/core/tree_test.exs
@@ -81,7 +81,7 @@ defmodule Xgit.Core.TreeTest do
       {:ok, repo: repo, objects_dir: objects_dir, xgit: xgit}
     end
 
-    def write_git_tree_and_read_xgit_tree_entries(repo, xgit) do
+    defp write_git_tree_and_read_xgit_tree_entries(repo, xgit) do
       {output, 0} = System.cmd("git", ["write-tree", "--missing-ok"], cd: repo)
       tree_id = String.trim(output)
 

--- a/test/xgit/core/tree_test.exs
+++ b/test/xgit/core/tree_test.exs
@@ -162,9 +162,16 @@ defmodule Xgit.Core.TreeTest do
              ]
     end
 
-    # test "no such object"
+    test "object is not a tree" do
+      object = %Object{
+        type: :blob,
+        content: 'test content\n',
+        size: 13,
+        id: "d670460b4b4aece5915caf5c68d12f560a9fe3e4"
+      }
 
-    # test "object is not a tree"
+      assert {:error, :not_a_tree} = Tree.from_object(object)
+    end
   end
 
   describe "to_object/1" do


### PR DESCRIPTION
## Changes in This Pull Request
Convert a raw binary object containing a tree to the `Xgit.Core.Tree` struct.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [ ] There is test coverage for all changes. _IN PROGRESS_
- [x] All cases where a literal value is returned use the `cover` macro to force code coverage.
- ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
