### PR TITLE
Tests in WriteTreeTest had bad name for `describe` block.

### DIFF
--- a/test/xgit/plumbing/write_tree_test.exs
+++ b/test/xgit/plumbing/write_tree_test.exs
@@ -12,7 +12,7 @@ defmodule Xgit.Plumbing.WriteTreeTest do
 
   import FolderDiff
 
-  describe "to_tree_objects/2" do
+  describe "run/2" do
     test "happy path: empty dir cache" do
       assert_same_output(fn _git_dir -> nil end, fn _xgit_repo -> nil end)
     end


### PR DESCRIPTION
## Checklist
- [x] This PR represents a single feature, fix, or change.
- ~All applicable changes have been documented.~ _n/a_
- ~There is test coverage for all changes.~ _n/a_
- ~All cases where a literal value is returned use the `cover` macro to force code coverage.~ _n/a_
- ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
