### PR TITLE
Introduce Xgit.Core.Commit struct.

### DIFF
--- a/lib/xgit/core/commit.ex
+++ b/lib/xgit/core/commit.ex
@@ -1,0 +1,54 @@
+defmodule Xgit.Core.Commit do
+  @moduledoc ~S"""
+  Represents a git `commit` object in memory.
+  """
+  alias Xgit.Core.ObjectId
+  alias Xgit.Core.PersonIdent
+
+  import Xgit.Util.ForceCoverage
+
+  @typedoc ~S"""
+  This struct describes a single `commit` object so it can be manipulated in memory.
+
+  ## Struct Members
+
+  * `:tree`: (`Xgit.Core.ObjectId`) tree referenced by this commit
+  * `:parents`: (list of `Xgit.Core.ObjectId`) parent(s) of this commit
+  * `:author`: (`Xgit.Core.PersonIdent`) author of this commit
+  * `:committer`: (`Xgit.Core.PersonIdent`) committer for this commit
+  * `:message`: (bytelist) user-entered commit message (encoding unspecified)
+  """
+  @type t :: %__MODULE__{
+          tree: ObjectId.t(),
+          parents: [ObjectId.t()],
+          author: PersonIdent.t(),
+          committer: PersonIdent.t(),
+          message: [byte]
+        }
+
+  @enforce_keys [:tree, :author, :committer, :message]
+  defstruct [:tree, :author, :committer, :message, parents: []]
+
+  @doc ~S"""
+  Return `true` if the value is a commit struct that is valid.
+  """
+  @spec valid?(commit :: any) :: boolean
+  def valid?(commit)
+
+  def valid?(%__MODULE__{
+        tree: tree,
+        parents: parents,
+        author: %PersonIdent{} = author,
+        committer: %PersonIdent{} = committer,
+        message: message
+      })
+      when is_binary(tree) and is_list(parents) and is_list(message) do
+    ObjectId.valid?(tree) &&
+      Enum.all?(parents, &ObjectId.valid?(&1)) &&
+      PersonIdent.valid?(author) &&
+      PersonIdent.valid?(committer) &&
+      not Enum.empty?(message)
+  end
+
+  def valid?(_), do: cover(false)
+end

--- a/test/xgit/core/commit_test.exs
+++ b/test/xgit/core/commit_test.exs
@@ -1,0 +1,202 @@
+defmodule Xgit.Core.CommitTest do
+  use ExUnit.Case, async: true
+
+  alias Xgit.Core.Commit
+  alias Xgit.Core.PersonIdent
+
+  @invalid_pi %PersonIdent{
+    name: :bogus,
+    email: "author@example.com",
+    when: 1_142_878_501_000,
+    tz_offset: 150
+  }
+
+  describe "valid?/1" do
+    test "valid: no parent" do
+      assert Commit.valid?(%Commit{
+               tree: "be9bfa841874ccc9f2ef7c48d0c76226f89b7189",
+               author: pi("A. U. Thor <author@localhost> 1 +0000"),
+               committer: pi("A. U. Thor <author@localhost> 1 +0000"),
+               message: 'x'
+             })
+    end
+
+    test "valid: blank author" do
+      assert Commit.valid?(%Commit{
+               tree: "be9bfa841874ccc9f2ef7c48d0c76226f89b7189",
+               author: pi("<> 0 +0000"),
+               committer: pi("<> 0 +0000"),
+               message: 'x'
+             })
+    end
+
+    test "invalid: corrupt author 1" do
+      refute Commit.valid?(%Commit{
+               tree: "be9bfa841874ccc9f2ef7c48d0c76226f89b7189",
+               author: @invalid_pi,
+               committer: pi("<> 0 +0000"),
+               message: 'x'
+             })
+    end
+
+    test "invalid: corrupt author 2" do
+      refute Commit.valid?(%Commit{
+               tree: "be9bfa841874ccc9f2ef7c48d0c76226f89b7189",
+               author: "A. U. Thor <author@localhost> 1 +0000",
+               committer: pi("<> 0 +0000"),
+               message: 'x'
+             })
+    end
+
+    test "invalid: corrupt committer 1" do
+      refute Commit.valid?(%Commit{
+               tree: "be9bfa841874ccc9f2ef7c48d0c76226f89b7189",
+               author: pi("<> 0 +0000"),
+               committer: @invalid_pi,
+               message: 'x'
+             })
+    end
+
+    test "invalid: corrupt committer 2" do
+      refute Commit.valid?(%Commit{
+               tree: "be9bfa841874ccc9f2ef7c48d0c76226f89b7189",
+               author: pi("<> 0 +0000"),
+               committer: "A. U. Thor <author@localhost> 1 +0000",
+               message: 'x'
+             })
+    end
+
+    test "valid: one parent" do
+      assert Commit.valid?(%Commit{
+               tree: "be9bfa841874ccc9f2ef7c48d0c76226f89b7189",
+               parents: ["be9bfa841874ccc9f2ef7c48d0c76226f89b7189"],
+               author: pi("A. U. Thor <author@localhost> 1 +0000"),
+               committer: pi("A. U. Thor <author@localhost> 1 +0000"),
+               message: 'x'
+             })
+    end
+
+    test "valid: two parents" do
+      assert Commit.valid?(%Commit{
+               tree: "be9bfa841874ccc9f2ef7c48d0c76226f89b7189",
+               parents: [
+                 "be9bfa841874ccc9f2ef7c48d0c76226f89b7189",
+                 "be9bfa841874ccc9f2ef7c48d0c76226f89b7189"
+               ],
+               author: pi("A. U. Thor <author@localhost> 1 +0000"),
+               committer: pi("A. U. Thor <author@localhost> 1 +0000"),
+               message: 'x'
+             })
+    end
+
+    test "valid: 128 parents" do
+      assert Commit.valid?(%Commit{
+               tree: "be9bfa841874ccc9f2ef7c48d0c76226f89b7189",
+               parents: Enum.map(1..128, fn _ -> "be9bfa841874ccc9f2ef7c48d0c76226f89b7189" end),
+               author: pi("A. U. Thor <author@localhost> 1 +0000"),
+               committer: pi("A. U. Thor <author@localhost> 1 +0000"),
+               message: 'x'
+             })
+    end
+
+    test "valid: normal time" do
+      assert Commit.valid?(%Commit{
+               tree: "be9bfa841874ccc9f2ef7c48d0c76226f89b7189",
+               author: pi("A. U. Thor <author@localhost> 1222757360 -0730"),
+               committer: pi("A. U. Thor <author@localhost> 1222757360 -0730"),
+               message: 'x'
+             })
+    end
+
+    test "invalid: invalid tree 1" do
+      refute Commit.valid?(%Commit{
+               tree: 'be9bfa841874ccc9f2ef7c48d0c76226f89b7189',
+               author: pi("A. U. Thor <author@localhost> 1 +0000"),
+               committer: pi("A. U. Thor <author@localhost> 1 +0000"),
+               message: 'x'
+             })
+    end
+
+    test "invalid: invalid tree 2" do
+      refute Commit.valid?(%Commit{
+               tree: "be9bfa841874ccc9f2ef7c48d0c76226f89b718",
+               author: pi("A. U. Thor <author@localhost> 1 +0000"),
+               committer: pi("A. U. Thor <author@localhost> 1 +0000"),
+               message: 'x'
+             })
+    end
+
+    test "invalid: invalid tree 3" do
+      refute Commit.valid?(%Commit{
+               tree: "zzz9bfa841874ccc9f2ef7c48d0c76226f89b718",
+               author: pi("A. U. Thor <author@localhost> 1 +0000"),
+               committer: pi("A. U. Thor <author@localhost> 1 +0000"),
+               message: 'x'
+             })
+    end
+
+    test "invalid: invalid parent 1" do
+      refute Commit.valid?(%Commit{
+               tree: "be9bfa841874ccc9f2ef7c48d0c76226f89b7189",
+               parents: ["e9bfa841874ccc9f2ef7c48d0c76226f89b7189"],
+               author: pi("A. U. Thor <author@localhost> 1 +0000"),
+               committer: pi("A. U. Thor <author@localhost> 1 +0000"),
+               message: 'x'
+             })
+    end
+
+    test "invalid: invalid parent 2" do
+      refute Commit.valid?(%Commit{
+               tree: "be9bfa841874ccc9f2ef7c48d0c76226f89b7189",
+               parents: ['be9bfa841874ccc9f2ef7c48d0c76226f89b7189'],
+               author: pi("A. U. Thor <author@localhost> 1 +0000"),
+               committer: pi("A. U. Thor <author@localhost> 1 +0000"),
+               message: 'x'
+             })
+    end
+
+    test "invalid: invalid parent 3" do
+      refute Commit.valid?(%Commit{
+               tree: "be9bfa841874ccc9f2ef7c48d0c76226f89b7189",
+               parents: ["ze9bfa841874ccc9f2ef7c48d0c76226f89b7189"],
+               author: pi("A. U. Thor <author@localhost> 1 +0000"),
+               committer: pi("A. U. Thor <author@localhost> 1 +0000"),
+               message: 'x'
+             })
+    end
+
+    test "invalid: invalid parent 4" do
+      refute Commit.valid?(%Commit{
+               tree: "be9bfa841874ccc9f2ef7c48d0c76226f89b7189",
+               parents: ["Be9bfa841874ccc9f2ef7c48d0c76226f89b7189"],
+               author: pi("A. U. Thor <author@localhost> 1 +0000"),
+               committer: pi("A. U. Thor <author@localhost> 1 +0000"),
+               message: 'x'
+             })
+    end
+
+    test "invalid: no message" do
+      refute Commit.valid?(%Commit{
+               tree: "be9bfa841874ccc9f2ef7c48d0c76226f89b7189",
+               author: pi("A. U. Thor <author@localhost> 1 +0000"),
+               committer: pi("A. U. Thor <author@localhost> 1 +0000"),
+               message: ''
+             })
+    end
+
+    test "invalid: message is string" do
+      refute Commit.valid?(%Commit{
+               tree: "be9bfa841874ccc9f2ef7c48d0c76226f89b7189",
+               author: pi("A. U. Thor <author@localhost> 1 +0000"),
+               committer: pi("A. U. Thor <author@localhost> 1 +0000"),
+               message: "x"
+             })
+    end
+
+    defp pi(s) do
+      s
+      |> String.to_charlist()
+      |> PersonIdent.from_byte_list()
+    end
+  end
+end


### PR DESCRIPTION
## Changes in This Pull Request
This is an in-memory representation of a single commit.

Currently only has a `valid?/1` function.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] There is test coverage for all changes.
- [x] All cases where a literal value is returned use the `cover` macro to force code coverage.
- ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
