### PR TITLE
OnDiskRepoTestCase: Make path option easier to consume.

### DIFF
--- a/test/support/test/on_disk_repo_test_case.ex
+++ b/test/support/test/on_disk_repo_test_case.ex
@@ -13,24 +13,20 @@ defmodule Xgit.Test.OnDiskRepoTestCase do
 
   @doc ~S"""
   Returns a context with an on-disk repository set up.
+
+  Can optionally take a hard-wired path to use instead of the default
+  temporary directory. Use that when you need to debug a test that is
+  failing and you want to inspect the repo after the test completes.
   """
-  @spec repo! :: %{tmp_dir: Path.t(), xgit_path: Path.t(), xgit_repo: Repository.t()}
-  def repo!, do: git_init_repo(TempDirTestCase.tmp_dir!())
-
-  @doc ~S"""
-  Returns a context with an on-disk repository set up.
-
-  Unlike `repo!/0`, this takes a hard-wired path and uses that instead.
-  Ensures that this directory is created and empty.
-
-  Use this when debugging tests that fail so you can inspect contents
-  after the test run.
-  """
-  @spec repo!(dir :: Path.t()) :: %{
+  @spec repo!(path :: Path.t() | nil) :: %{
           tmp_dir: Path.t(),
           xgit_path: Path.t(),
           xgit_repo: Repository.t()
         }
+  def repo!(path \\ nil)
+
+  def repo!(nil), do: git_init_repo(TempDirTestCase.tmp_dir!())
+
   def repo!(dir) when is_binary(dir) do
     File.rm_rf!(dir)
     File.mkdir!(dir)


### PR DESCRIPTION
## Checklist
- [x] This PR represents a single feature, fix, or change.
- ~All applicable changes have been documented.~ _n/a_
- ~There is test coverage for all changes.~ _n/a_
- ~All cases where a literal value is returned use the `cover` macro to force code coverage.~ _n/a_
- ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
