### PR TITLE
Implement Xgit.Plumbing.CommitTree.

### DIFF
--- a/lib/xgit/plumbing/commit_tree.ex
+++ b/lib/xgit/plumbing/commit_tree.ex
@@ -22,6 +22,7 @@ defmodule Xgit.Plumbing.CommitTree do
           :invalid_repository
           | :invalid_tree
           | :invalid_parents
+          | :invalid_parent_ids
           | :invalid_message
           | :invalid_author
           | :invalid_committer
@@ -64,6 +65,9 @@ defmodule Xgit.Plumbing.CommitTree do
   does not exist.
 
   `{:error, :invalid_parents}` if the `:parents` option is not a list.
+
+  `{:error, :invalid_parent_ids}` if the `:parents` option contains any entries that
+  do not reference valid commit objects.
 
   `{:error, :invalid_message}` if the `:message` option isn't a valid byte string.
 

--- a/lib/xgit/plumbing/commit_tree.ex
+++ b/lib/xgit/plumbing/commit_tree.ex
@@ -1,0 +1,143 @@
+defmodule Xgit.Plumbing.CommitTree do
+  @moduledoc ~S"""
+  Creates a new commit object based on the provided tree object.
+
+  Analogous to
+  [`git commit-tree`](https://git-scm.com/docs/git-commit-tree).
+  """
+
+  import Xgit.Util.ForceCoverage
+
+  # alias Xgit.Core.Commit
+  alias Xgit.Core.Object
+  alias Xgit.Core.ObjectId
+  alias Xgit.Core.PersonIdent
+  alias Xgit.Core.Tree
+  alias Xgit.Repository
+
+  @typedoc ~S"""
+  Reason codes that can be returned by `run/2`.
+  """
+  @type reason ::
+          :invalid_repository
+          | Repository.put_loose_object_reason()
+
+  # TODO: More to come, I'm sure.
+
+  @doc ~S"""
+  Creates a new commit object based on the provided tree object and parent commits.
+
+  A commit object may have any number of parents. With exactly one parent, it is an
+  ordinary commit. Having more than one parent makes the commit a merge between
+  several lines of history. Initial (root) commits have no parents.
+
+  ## Parameters
+
+  `repository` is the `Xgit.Repository` (PID) to search for the object.
+
+  ## Options
+
+  `tree`: (`Xgit.Core.ObjectId`, required) ID of tree object
+
+  `parents`: (list of `Xgit.Core.ObjectId`) parent commit object IDs
+
+  `message`: (byte list, required) commit message
+
+  `author`: (`Xgit.Core.PersonIdent`, required) author name, email, timestamp
+
+  `committer`: (`Xgit.Core.PersonIdent`) committer name, email timestamp
+  (defaults to `author` if not specified)
+
+  ## Return Value
+
+  `{:ok, object_id}` with the object ID for the commit that was generated.
+
+  `{:error, :invalid_repository}` if `repository` doesn't represent a valid
+  `Xgit.Repository` process.
+
+  Reason codes may also come from the following functions:
+
+  * **TODO**: Identify other reason codes and functions that contribute reasons.
+  """
+  @spec run(repository :: Repository.t(),
+          tree: ObjectId.t(),
+          parents: [ObjectId.t()],
+          message: [byte],
+          author: PersonIdent.t(),
+          committer: PersonIdent.t()
+        ) ::
+          {:ok, object_id :: ObjectId.t()}
+          | {:error, reason :: reason}
+  def run(repository, opts \\ []) when is_pid(repository) do
+    with {:repository_valid?, true} <- {:repository_valid?, Repository.valid?(repository)},
+         {_tree, _parents, _message, _author, _committer} <- validate_options(repository, opts) do
+      # validate: all objects referenced by tree are present?
+      :unimplemented
+    else
+      {:repository_valid?, _} -> cover {:error, :invalid_repository}
+      {:error, reason} -> cover {:error, reason}
+    end
+  end
+
+  defp validate_options(repository, opts) do
+    with {:ok, tree_id} <- validate_tree(repository, Keyword.get(opts, :tree)),
+         {:ok, parent_ids} <- validate_parents(repository, Keyword.get(opts, :parents)),
+         {:ok, message} <- validate_message(Keyword.get(opts, :message)),
+         {:ok, author} <- validate_person_ident(Keyword.get(opts, :author), :author_invalid),
+         {:ok, committer} <-
+           validate_person_ident(Keyword.get(opts, :committer, author), :committer_invalid) do
+      cover {tree_id, parent_ids, message, author, committer}
+    else
+      {:error, reason} -> cover {:error, reason}
+    end
+  end
+
+  defp validate_tree(repository, tree_id) do
+    with true <- ObjectId.valid?(tree_id),
+         {:ok, %Object{id: id} = object} <- Repository.get_object(repository, tree_id),
+         {:ok, _tree} <- Tree.from_object(object) do
+      cover {:ok, id}
+    else
+      _ -> cover {:error, :invalid_tree}
+    end
+  end
+
+  defp validate_parents(_repository, nil), do: {:ok, []}
+
+  defp validate_parents(repository, parent_ids) when is_list(parent_ids) do
+    if Enum.all?(parent_ids, &commit_id_valid?(repository, &1)) do
+      cover {:ok, parent_ids}
+    else
+      cover {:error, :invalid_parent_ids}
+    end
+  end
+
+  defp validate_parents(_repository, _parents), do: {:error, :invalid_parents}
+
+  defp commit_id_valid?(repository, parent_id) do
+    with true <- ObjectId.valid?(parent_id),
+         {:ok, %Object{type: :commit}} <- Repository.get_object(repository, parent_id) do
+      cover true
+    else
+      _ -> cover false
+    end
+  end
+
+  defp validate_message(message) when is_list(message) do
+    if Enum.all?(message, &is_integer/1) do
+      cover {:ok, message}
+    else
+      cover {:error, :invalid_message}
+    end
+  end
+
+  defp validate_message(_message), do: cover({:error, :invalid_message})
+
+  defp validate_person_ident(person_ident, invalid_reason) do
+    if PersonIdent.valid?(person_ident) do
+      cover {:ok, person_ident}
+    else
+      cover {:error, invalid_reason}
+    end
+  end
+end

--- a/lib/xgit/plumbing/commit_tree.ex
+++ b/lib/xgit/plumbing/commit_tree.ex
@@ -28,8 +28,6 @@ defmodule Xgit.Plumbing.CommitTree do
           | :invalid_committer
           | Repository.put_loose_object_reason()
 
-  # TODO: More to come, I'm sure.
-
   @doc ~S"""
   Creates a new commit object based on the provided tree object and parent commits.
 
@@ -75,9 +73,7 @@ defmodule Xgit.Plumbing.CommitTree do
 
   `{:error, :invalid_committer}` if the `:committer` option isn't a valid `PersonIdent` struct.
 
-  Reason codes may also come from the following functions:
-
-  * **TODO**: Identify other reason codes and functions that contribute reasons.
+  Reason codes may also come from `Xgit.Repository.put_loose_object/2`.
   """
   @spec run(repository :: Repository.t(),
           tree: ObjectId.t(),

--- a/lib/xgit/plumbing/commit_tree.ex
+++ b/lib/xgit/plumbing/commit_tree.ex
@@ -88,7 +88,7 @@ defmodule Xgit.Plumbing.CommitTree do
     with {:repository_valid?, true} <- {:repository_valid?, Repository.valid?(repository)},
          {_tree, _parents, _message, _author, _committer} <- validate_options(repository, opts) do
       # validate: all objects referenced by tree are present?
-      :unimplemented
+      cover :unimplemented
     else
       {:repository_valid?, _} -> cover {:error, :invalid_repository}
       {:error, reason} -> cover {:error, reason}

--- a/lib/xgit/plumbing/commit_tree.ex
+++ b/lib/xgit/plumbing/commit_tree.ex
@@ -166,7 +166,15 @@ defmodule Xgit.Plumbing.CommitTree do
       parents: parents,
       author: author,
       committer: committer,
-      message: message
+      message: ensure_trailing_newline(message)
     }
+  end
+
+  defp ensure_trailing_newline(message) do
+    if List.last(message) == 10 do
+      message
+    else
+      message ++ '\n'
+    end
   end
 end

--- a/test/xgit/plumbing/commit_tree_test.exs
+++ b/test/xgit/plumbing/commit_tree_test.exs
@@ -47,6 +47,24 @@ defmodule Xgit.Plumbing.CommitTreeTest do
       assert_folders_are_equal(ref_path, xgit_path)
     end
 
+    test "happy path: no parents (line ending provided)" do
+      %{xgit_path: ref_path, tree_id: tree_id} = setup_with_valid_tree!()
+
+      assert {ref_commit_id_str, 0} =
+               System.cmd("git", ["commit-tree", tree_id, "-m", "xxx"], cd: ref_path, env: @env)
+
+      %{xgit_path: xgit_path, xgit_repo: xgit_repo, tree_id: ^tree_id} = setup_with_valid_tree!()
+
+      assert {:ok, commit_id} =
+               CommitTree.run(xgit_repo,
+                 tree: tree_id,
+                 message: 'xxx\n',
+                 author: @valid_pi
+               )
+
+      assert_folders_are_equal(ref_path, xgit_path)
+    end
+
     test "happy path: one parent" do
       %{xgit_path: ref_path, tree_id: tree_id, parent_id: parent_id} =
         setup_with_valid_parent_commit!()

--- a/test/xgit/plumbing/commit_tree_test.exs
+++ b/test/xgit/plumbing/commit_tree_test.exs
@@ -307,7 +307,7 @@ defmodule Xgit.Plumbing.CommitTreeTest do
                  tree: tree_id,
                  parents: [parent_id],
                  message: 'message',
-                 author: Map.put(@valid_pi, :tz_offset, 15000),
+                 author: Map.put(@valid_pi, :tz_offset, 15_000),
                  committer: @valid_pi
                )
     end
@@ -336,7 +336,7 @@ defmodule Xgit.Plumbing.CommitTreeTest do
                  parents: [parent_id],
                  message: 'message',
                  author: @valid_pi,
-                 committer: Map.put(@valid_pi, :tz_offset, 15000)
+                 committer: Map.put(@valid_pi, :tz_offset, 15_000)
                )
     end
 

--- a/test/xgit/plumbing/commit_tree_test.exs
+++ b/test/xgit/plumbing/commit_tree_test.exs
@@ -1,0 +1,74 @@
+defmodule Xgit.Plumbing.CommitTreeTest do
+  use ExUnit.Case, async: true
+
+  alias Xgit.Core.Object
+  alias Xgit.Core.PersonIdent
+  # alias Xgit.GitInitTestCase
+  alias Xgit.Plumbing.CommitTree
+  # alias Xgit.Plumbing.HashObject
+  # alias Xgit.Plumbing.UpdateIndex.CacheInfo
+  # alias Xgit.Plumbing.WriteTree
+  alias Xgit.Repository
+  # alias Xgit.Repository.WorkingTree
+  alias Xgit.Test.OnDiskRepoTestCase
+
+  # import FolderDiff
+
+  describe "run/2" do
+    @valid_pi %PersonIdent{
+      name: "A. U. Thor",
+      email: "author@example.com",
+      when: 1_142_878_501_000,
+      tz_offset: 150
+    }
+
+    test "error: invalid repo" do
+      {:ok, not_repo} = GenServer.start_link(NotValid, nil)
+
+      assert {:error, :invalid_repository} =
+               CommitTree.run(not_repo,
+                 tree: "9d252945c1d3c553a30361214db02892d1ea4876",
+                 author: @valid_pi
+               )
+    end
+
+    test "error: invalid tree object ID" do
+      %{xgit_repo: xgit_repo} = OnDiskRepoTestCase.repo!()
+
+      assert {:error, :invalid_tree} =
+               CommitTree.run(xgit_repo,
+                 tree: "9d252945c1d3c553a30361214db02892d1ea487",
+                 author: @valid_pi
+               )
+    end
+
+    test "error: tree object doesn't exist" do
+      %{xgit_repo: xgit_repo} = OnDiskRepoTestCase.repo!()
+
+      assert {:error, :invalid_tree} =
+               CommitTree.run(xgit_repo,
+                 tree: "9d252945c1d3c553a30361214db02892d1ea4876",
+                 author: @valid_pi
+               )
+    end
+
+    test "error: tree object isn't a tree" do
+      %{xgit_repo: xgit_repo} = OnDiskRepoTestCase.repo!()
+
+      object = %Object{
+        type: :blob,
+        content: 'test content\n',
+        size: 13,
+        id: "d670460b4b4aece5915caf5c68d12f560a9fe3e4"
+      }
+
+      :ok = Repository.put_loose_object(xgit_repo, object)
+
+      assert {:error, :invalid_tree} =
+               CommitTree.run(xgit_repo,
+                 tree: "d670460b4b4aece5915caf5c68d12f560a9fe3e4",
+                 author: @valid_pi
+               )
+    end
+  end
+end


### PR DESCRIPTION
## Changes in This Pull Request
Creates a new commit object based on the provided tree object.

Analogous to [`git commit-tree`](https://git-scm.com/docs/git-commit-tree).

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] There is test coverage for all changes.
- [x] All cases where a literal value is returned use the `cover` macro to force code coverage.
- ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
