### PR TITLE
OnDiskRepoTestCase: Add functions for setting up tree and commit objects.

### DIFF
--- a/test/support/test/on_disk_repo_test_case.ex
+++ b/test/support/test/on_disk_repo_test_case.ex
@@ -1,7 +1,6 @@
 defmodule Xgit.Test.OnDiskRepoTestCase do
-  @moduledoc ~S"""
-  (Testing only) Test case that sets up a temporary directory with an on-disk repositort.
-  """
+  @moduledoc false
+  # (Testing only) Test case that sets up a temporary directory with an on-disk repository.
   use ExUnit.CaseTemplate
 
   alias Xgit.Repository.OnDisk
@@ -38,5 +37,132 @@ defmodule Xgit.Test.OnDiskRepoTestCase do
     {:ok, xgit_repo} = OnDisk.start_link(work_dir: xgit_path)
 
     Map.merge(context, %{xgit_path: xgit_path, xgit_repo: xgit_repo})
+  end
+
+  @doc ~S"""
+  Returns a pre-configured environment for a known author/committer ID and timestamp.
+  """
+  @spec sample_commit_env() :: [{String.t(), String.t()}]
+  def sample_commit_env do
+    [
+      {"GIT_AUTHOR_DATE", "1142878449 +0230"},
+      {"GIT_COMMITTER_DATE", "1142878449 +0230"},
+      {"GIT_AUTHOR_EMAIL", "author@example.com"},
+      {"GIT_COMMITTER_EMAIL", "author@example.com"},
+      {"GIT_AUTHOR_NAME", "A. U. Thor"},
+      {"GIT_COMMITTER_NAME", "A. U. Thor"}
+    ]
+  end
+
+  @doc ~S"""
+  Returns a context with an on-disk repository set up.
+
+  This repository has a tree object with one file in it.
+
+  Can optionally take a hard-wired path to use instead of the default
+  temporary directory. Use that when you need to debug a test that is
+  failing and you want to inspect the repo after the test completes.
+  """
+  @spec setup_with_valid_tree!(path :: Path.t() | nil) :: %{
+          tmp_dir: Path.t(),
+          xgit_path: Path.t(),
+          xgit_repo: Repository.t(),
+          tree_id: binary()
+        }
+  def setup_with_valid_tree!(path \\ nil) do
+    %{xgit_path: xgit_path} = context = repo!(path)
+
+    test_content_path = Temp.path!()
+    File.write!(test_content_path, "test content\n")
+
+    {object_id_str, 0} =
+      System.cmd(
+        "git",
+        [
+          "hash-object",
+          "-w",
+          "--",
+          test_content_path
+        ],
+        cd: xgit_path
+      )
+
+    object_id = String.trim(object_id_str)
+
+    {_output, 0} =
+      System.cmd(
+        "git",
+        [
+          "update-index",
+          "--add",
+          "--cacheinfo",
+          "100644",
+          object_id,
+          "test"
+        ],
+        cd: xgit_path
+      )
+
+    {tree_id_str, 0} =
+      System.cmd(
+        "git",
+        [
+          "write-tree"
+        ],
+        cd: xgit_path
+      )
+
+    tree_id = String.trim(tree_id_str)
+
+    Map.put(context, :tree_id, tree_id)
+  end
+
+  @doc ~S"""
+  Returns a context with an on-disk repository set up.
+
+  This repository has a tree object with one file in it and an
+  empty commit.
+
+  Can optionally take a hard-wired path to use instead of the default
+  temporary directory. Use that when you need to debug a test that is
+  failing and you want to inspect the repo after the test completes.
+  """
+  @spec setup_with_valid_parent_commit!(path :: Path.t() | nil) :: %{
+          tmp_dir: Path.t(),
+          xgit_path: Path.t(),
+          xgit_repo: Repository.t(),
+          tree_id: String.t(),
+          parent_id: String.t()
+        }
+  def setup_with_valid_parent_commit!(path \\ nil) do
+    %{xgit_path: xgit_path} = context = setup_with_valid_tree!(path)
+
+    {empty_tree_id_str, 0} =
+      System.cmd(
+        "git",
+        [
+          "write-tree"
+        ],
+        cd: xgit_path
+      )
+
+    empty_tree_id = String.trim(empty_tree_id_str)
+
+    {parent_id_str, 0} =
+      System.cmd(
+        "git",
+        [
+          "commit-tree",
+          "-m",
+          "empty",
+          empty_tree_id
+        ],
+        cd: xgit_path,
+        env: sample_commit_env()
+      )
+
+    parent_id = String.trim(parent_id_str)
+
+    Map.put(context, :parent_id, parent_id)
   end
 end


### PR DESCRIPTION
## Changes in This Pull Request
Functions that were private in `commit_tree_test.exs` will be useful elsewhere. Add them to `OnDiskRepoTestCase`.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- ~All applicable changes have been documented.~ _n/a_
- ~There is test coverage for all changes.~ _n/a_
- ~All cases where a literal value is returned use the `cover` macro to force code coverage.~ _n/a_
- ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- ~ Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
