### PR TITLE
Add Xgit.Core.Ref.valid_name?/1.

### DIFF
--- a/lib/xgit/core/ref.ex
+++ b/lib/xgit/core/ref.ex
@@ -33,6 +33,13 @@ defmodule Xgit.Core.Ref do
   defstruct [:name, :target]
 
   @doc ~S"""
+  Return `true` if the string describes a valid reference name.
+  """
+  @spec valid_name?(name :: any) :: boolean
+  def valid_name?(name) when is_binary(name), do: valid_name?(name, false, false)
+  def valid_name?(_), do: cover(false)
+
+  @doc ~S"""
   Return `true` if the struct describes a valid reference.
 
   ## Options

--- a/test/xgit/core/ref_test.exs
+++ b/test/xgit/core/ref_test.exs
@@ -7,16 +7,20 @@ defmodule Xgit.Core.RefTest do
     assert {_, 0} = System.cmd("git", check_ref_format_args(name, opts))
     assert Ref.valid?(%Ref{name: name, target: "155b7b4b7a6b798725df04a6cfcfb1aa042f0834"}, opts)
 
-    if Enum.empty?(opts) && String.starts_with?(name, "refs/"),
-      do: assert(Ref.valid?(%Ref{name: "refs/heads/master", target: "ref: #{name}"}, opts))
+    if Enum.empty?(opts) && String.starts_with?(name, "refs/") do
+      assert Ref.valid?(%Ref{name: "refs/heads/master", target: "ref: #{name}"}, opts)
+      assert Ref.valid_name?(name)
+    end
   end
 
   defp refute_valid_name(name, opts \\ []) do
     assert {_, 1} = System.cmd("git", check_ref_format_args(name, opts))
     refute Ref.valid?(%Ref{name: name, target: "155b7b4b7a6b798725df04a6cfcfb1aa042f0834"}, opts)
 
-    if Enum.empty?(opts) && String.starts_with?(name, "refs/"),
-      do: refute(Ref.valid?(%Ref{name: "refs/heads/master", target: "ref: #{name}"}, opts))
+    if Enum.empty?(opts) && String.starts_with?(name, "refs/") do
+      refute Ref.valid?(%Ref{name: "refs/heads/master", target: "ref: #{name}"}, opts)
+      refute Ref.valid_name?(name)
+    end
   end
 
   defp check_ref_format_args(name, opts) do
@@ -175,5 +179,11 @@ defmodule Xgit.Core.RefTest do
              name: "refs/heads/master",
              target: "155b7b4b7a6b798725df04a6cfcfb1aa042f0834"
            })
+  end
+
+  test "valid_name?/1 not a string" do
+    refute Ref.valid_name?('refs/heads/master')
+    refute Ref.valid_name?(42)
+    refute Ref.valid_name?(nil)
   end
 end


### PR DESCRIPTION
## Changes in This Pull Request
Shortcut for existing validation logic. Allows you to validate a ref name without constructing a full `Ref` struct.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] There is test coverage for all changes.
- [x] All cases where a literal value is returned use the `cover` macro to force code coverage.
- ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
