### PR TITLE
Implement Xgit.Util.FileUtils.recursive_files!/1.

### DIFF
--- a/lib/xgit/util/file_utils.ex
+++ b/lib/xgit/util/file_utils.ex
@@ -17,7 +17,8 @@ defmodule Xgit.Util.FileUtils do
         cover [path]
 
       File.dir?(path) ->
-        File.ls!(path)
+        path
+        |> File.ls!()
         |> Enum.map(&Path.join(path, &1))
         |> Enum.map(&recursive_files!/1)
         |> Enum.concat()

--- a/lib/xgit/util/file_utils.ex
+++ b/lib/xgit/util/file_utils.ex
@@ -1,0 +1,27 @@
+defmodule Xgit.Util.FileUtils do
+  @moduledoc false
+
+  # Internal utility for recursively listing the contents of a directory.
+
+  @doc ~S"""
+  Recursively list the files of a directory.
+
+  Directories are scanned, but their paths are not reported as part of the result.
+  """
+  @spec recursive_files!(path :: Path.t()) :: [Path.t()]
+  def recursive_files!(path \\ ".") do
+    cond do
+      File.regular?(path) ->
+        [path]
+
+      File.dir?(path) ->
+        File.ls!(path)
+        |> Enum.map(&Path.join(path, &1))
+        |> Enum.map(&recursive_files!/1)
+        |> Enum.concat()
+
+      true ->
+        []
+    end
+  end
+end

--- a/lib/xgit/util/file_utils.ex
+++ b/lib/xgit/util/file_utils.ex
@@ -3,6 +3,8 @@ defmodule Xgit.Util.FileUtils do
 
   # Internal utility for recursively listing the contents of a directory.
 
+  import Xgit.Util.ForceCoverage
+
   @doc ~S"""
   Recursively list the files of a directory.
 
@@ -12,7 +14,7 @@ defmodule Xgit.Util.FileUtils do
   def recursive_files!(path \\ ".") do
     cond do
       File.regular?(path) ->
-        [path]
+        cover [path]
 
       File.dir?(path) ->
         File.ls!(path)
@@ -21,7 +23,7 @@ defmodule Xgit.Util.FileUtils do
         |> Enum.concat()
 
       true ->
-        []
+        cover []
     end
   end
 end

--- a/test/xgit/util/file_utils_test.exs
+++ b/test/xgit/util/file_utils_test.exs
@@ -1,0 +1,54 @@
+defmodule Xgit.Util.FileUtilsTest do
+  use ExUnit.Case, async: true
+
+  import Xgit.Test.TempDirTestCase
+
+  alias Xgit.Util.FileUtils
+
+  describe "recursive_files!/1" do
+    test "empty dir" do
+      %{tmp_dir: tmp} = tmp_dir!()
+      assert [] = FileUtils.recursive_files!(tmp)
+    end
+
+    test "dir doesn't exist" do
+      %{tmp_dir: tmp} = tmp_dir!()
+      foo_path = Path.join(tmp, "foo")
+      assert [] = FileUtils.recursive_files!(foo_path)
+    end
+
+    test "one file" do
+      %{tmp_dir: tmp} = tmp_dir!()
+      foo_path = Path.join(tmp, "foo")
+      File.write!(foo_path, "foo")
+      assert [^foo_path] = FileUtils.recursive_files!(tmp)
+    end
+
+    test "one file, nested" do
+      %{tmp_dir: tmp} = tmp_dir!()
+      bar_dir_path = Path.join(tmp, "bar")
+      File.mkdir_p!(bar_dir_path)
+      foo_path = Path.join(bar_dir_path, "foo")
+      File.write!(foo_path, "foo")
+      assert [^foo_path] = FileUtils.recursive_files!(tmp)
+    end
+
+    test "three file" do
+      %{tmp_dir: tmp} = tmp_dir!()
+
+      foo_path = Path.join(tmp, "foo")
+      File.write!(foo_path, "foo")
+
+      bar_path = Path.join(tmp, "bar")
+      File.write!(bar_path, "bar")
+
+      blah_path = Path.join(tmp, "blah")
+      File.write!(blah_path, "blah")
+
+      assert [^bar_path, ^blah_path, ^foo_path] =
+               tmp
+               |> FileUtils.recursive_files!()
+               |> Enum.sort()
+    end
+  end
+end


### PR DESCRIPTION
## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] There is test coverage for all changes.
- [x] All cases where a literal value is returned use the `cover` macro to force code coverage.
- ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
