### PR TITLE
[API BREAKING] Add reference operations to Repository interface.

### DIFF
--- a/lib/xgit/repository.ex
+++ b/lib/xgit/repository.ex
@@ -263,12 +263,13 @@ defmodule Xgit.Repository do
   ## TO DO
 
   Support for `old_value` (i.e. only replace if `old_value` matches).
+  https://github.com/elixir-git/xgit/issues/225
 
   Support for ref log. https://github.com/elixir-git/xgit/issues/224
 
-  Support for `--no-deref` option. https://github.com/elixir-git/xgit/issues/224
+  Support for `--no-deref` option. https://github.com/elixir-git/xgit/issues/226
 
-  Support for `-d` option (delete ref).
+  Support for `-d` option (delete ref). https://github.com/elixir-git/xgit/issues/227
 
   ## Return Value
 
@@ -334,7 +335,7 @@ defmodule Xgit.Repository do
 
   ## TO DO
 
-  Dereference?
+  Dereference? https://github.com/elixir-git/xgit/issues/228
 
   ## Return Value
 

--- a/lib/xgit/repository.ex
+++ b/lib/xgit/repository.ex
@@ -264,9 +264,9 @@ defmodule Xgit.Repository do
 
   Support for `old_value` (i.e. only replace if `old_value` matches).
 
-  Support for ref log.
+  Support for ref log. https://github.com/elixir-git/xgit/issues/224
 
-  Support for `--no-deref` option.
+  Support for `--no-deref` option. https://github.com/elixir-git/xgit/issues/224
 
   Support for `-d` option (delete ref).
 
@@ -371,7 +371,6 @@ defmodule Xgit.Repository do
   @callback handle_get_ref(state :: any, name :: String.t(), opts :: Keyword.t()) ::
               {:ok, ref :: Xgit.Core.Ref.t(), state :: any}
               | {:error, reason :: get_ref_reason, state :: any}
-
 
   # TO DO: Add a `pack_refs` function. https://github.com/elixir-git/xgit/issues/223
 

--- a/lib/xgit/repository.ex
+++ b/lib/xgit/repository.ex
@@ -372,6 +372,9 @@ defmodule Xgit.Repository do
               {:ok, ref :: Xgit.Core.Ref.t(), state :: any}
               | {:error, reason :: get_ref_reason, state :: any}
 
+
+  # TO DO: Add a `pack_refs` function. https://github.com/elixir-git/xgit/issues/223
+
   @impl true
   def handle_call(:valid_repository?, _from, state), do: {:reply, :valid_repository, state}
 

--- a/lib/xgit/repository.ex
+++ b/lib/xgit/repository.ex
@@ -214,7 +214,7 @@ defmodule Xgit.Repository do
   @typedoc ~S"""
   Error codes that can be returned by `list_refs/1`.
   """
-  @type list_refs_reason :: :tbd_no_known_errors_yet
+  @type list_refs_reason :: File.posix()
 
   @doc ~S"""
   Lists all references in the repository.
@@ -224,7 +224,7 @@ defmodule Xgit.Repository do
   `{:ok, refs}` if successful. `refs` will be a list of `Xgit.Core.Ref` structs.
   The sequence of the list is unspecified.
 
-  `{:error, reason}` if unable. TBD: Why might this fail?
+  `{:error, reason}` if unable. See `list_refs_reason`.
   """
   @spec list_refs(repository :: t) ::
           {:ok, refs :: [Ref.t()]} | {:error, reason :: list_refs_reason}
@@ -241,7 +241,8 @@ defmodule Xgit.Repository do
   Should return `{:ok, refs, state}` if read successfully. `refs` should be a list
   of `Xgit.Core.Ref` structs.
 
-  Should return `{:error, reason}` if unable. TBD: Why might this fail?
+  Should return `{:error, reason}` if unable. Currently only `File.posix` reasons
+  are expected.
   """
   @callback handle_list_refs(state :: any) ::
               {:ok, refs :: [Ref], state :: any}

--- a/lib/xgit/repository.ex
+++ b/lib/xgit/repository.ex
@@ -284,7 +284,7 @@ defmodule Xgit.Repository do
   """
   @spec put_ref(repository :: t, ref :: Ref.t(), opts :: Keyword.t()) ::
           :ok | {:error, reason :: put_ref_reason}
-  def put_ref(repository, %Ref{} = ref, opts) when is_pid(repository) and is_list(opts) do
+  def put_ref(repository, %Ref{} = ref, opts \\ []) when is_pid(repository) and is_list(opts) do
     if Ref.valid?(ref) do
       GenServer.call(repository, {:put_ref, ref, []})
     else

--- a/lib/xgit/repository.ex
+++ b/lib/xgit/repository.ex
@@ -245,7 +245,7 @@ defmodule Xgit.Repository do
   Should return `{:error, reason}` if unable. TBD: Why might this fail?
   """
   @callback handle_list_refs(state :: any) ::
-              {:ok, refs :: [Xgit.Core.Refs], state :: any}
+              {:ok, refs :: [Ref], state :: any}
               | {:error, reason :: list_refs_reason, state :: any}
 
   @typedoc ~S"""

--- a/lib/xgit/repository.ex
+++ b/lib/xgit/repository.ex
@@ -252,7 +252,8 @@ defmodule Xgit.Repository do
   Error codes that can be returned by `put_ref/2`.
   """
 
-  @type put_ref_reason :: :invalid_ref | :cant_create_file
+  @type put_ref_reason ::
+          :invalid_ref | :cant_create_file | :target_not_found | :target_not_commit
 
   @doc ~S"""
   Writes or updates a reference in the repository.
@@ -276,6 +277,10 @@ defmodule Xgit.Repository do
   `{:error, :invalid_ref}` if the `Xgit.Core.Ref` structure is invalid.
 
   `{:error, :cant_create_file}` if unable to create the storage for the reference.
+
+  `{:error, :target_not_found}` if the target object does not exist in the repository.
+
+  `{:error, :target_not_commit}` if the target object is not of type `commit`.
   """
   @spec put_ref(repository :: t, ref :: Ref.t(), opts :: Keyword.t()) ::
           :ok | {:error, reason :: put_ref_reason}
@@ -298,6 +303,12 @@ defmodule Xgit.Repository do
 
   Should return `{:error, :cant_create_file}` if unable to create the storage for
   the loose object.
+
+  Should return `{:error, :target_not_found}` if the target object does not
+  exist in the repository.
+
+  Should return `{:error, :target_not_commit}` if the target object is not
+  of type `commit`.
   """
   @callback handle_put_ref(state :: any, ref :: Ref.t(), opts :: Keyword.t()) ::
               {:ok, state :: any} | {:error, reason :: put_ref_reason, state :: any}

--- a/lib/xgit/repository.ex
+++ b/lib/xgit/repository.ex
@@ -32,6 +32,7 @@ defmodule Xgit.Repository do
 
   alias Xgit.Core.Object
   alias Xgit.Core.ObjectId
+  alias Xgit.Core.Ref
   alias Xgit.Repository.WorkingTree
 
   require Logger
@@ -175,7 +176,6 @@ defmodule Xgit.Repository do
   @typedoc ~S"""
   Error codes that can be returned by `put_loose_object/2`.
   """
-
   @type put_loose_object_reason :: :cant_create_file | :object_exists
 
   @doc ~S"""
@@ -211,6 +211,152 @@ defmodule Xgit.Repository do
   @callback handle_put_loose_object(state :: any, object :: Object.t()) ::
               {:ok, state :: any} | {:error, reason :: put_loose_object_reason, state :: any}
 
+  @typedoc ~S"""
+  Error codes that can be returned by `list_refs/1`.
+  """
+  @type list_refs_reason :: :tbd_no_known_errors_yet
+
+  @doc ~S"""
+  Lists all references in the repository.
+
+  ## Return Value
+
+  `{:ok, refs}` if successful. `refs` will be a list of `Xgit.Core.Ref` structs.
+  The sequence of the list is unspecified.
+
+  `{:error, reason}` if unable. TBD: Why might this fail?
+  """
+  @spec list_refs(repository :: t) ::
+          {:ok, refs :: [Ref.t()]} | {:error, reason :: list_refs_reason}
+  def list_refs(repository) when is_pid(repository),
+    do: GenServer.call(repository, :list_refs)
+
+  @doc ~S"""
+  Lists
+  Lists all references in the repository.
+
+  Called when `list_refs/1` is called.
+
+  ## Return Value
+
+  Should return `{:ok, refs, state}` if read successfully. `refs` should be a list
+  of `Xgit.Core.Ref` structs.
+
+  Should return `{:error, reason}` if unable. TBD: Why might this fail?
+  """
+  @callback handle_list_refs(state :: any) ::
+              {:ok, refs :: [Xgit.Core.Refs], state :: any}
+              | {:error, reason :: list_refs_reason, state :: any}
+
+  @typedoc ~S"""
+  Error codes that can be returned by `put_ref/2`.
+  """
+
+  @type put_ref_reason :: :invalid_ref | :cant_create_file
+
+  @doc ~S"""
+  Writes or updates a reference in the repository.
+
+  If any existing reference exists with this name, it will be replaced.
+
+  ## TO DO
+
+  Support for `old_value` (i.e. only replace if `old_value` matches).
+
+  Support for ref log.
+
+  Support for `--no-deref` option.
+
+  Support for `-d` option (delete ref).
+
+  ## Return Value
+
+  `:ok` if written successfully.
+
+  `{:error, :invalid_ref}` if the `Xgit.Core.Ref` structure is invalid.
+
+  `{:error, :cant_create_file}` if unable to create the storage for the reference.
+  """
+  @spec put_ref(repository :: t, ref :: Ref.t(), opts :: Keyword.t()) ::
+          :ok | {:error, reason :: put_ref_reason}
+  def put_ref(repository, %Ref{} = ref, opts) when is_pid(repository) and is_list(opts) do
+    if Ref.valid?(ref) do
+      GenServer.call(repository, {:put_ref, ref, []})
+    else
+      cover {:error, :invalid_ref}
+    end
+  end
+
+  @doc ~S"""
+  Writes or updates a reference in the repository.
+
+  Called when `put_ref/3` is called.
+
+  ## Return Value
+
+  Should return `{:ok, state}` if written successfully.
+
+  Should return `{:error, :cant_create_file}` if unable to create the storage for
+  the loose object.
+  """
+  @callback handle_put_ref(state :: any, ref :: Ref.t(), opts :: Keyword.t()) ::
+              {:ok, state :: any} | {:error, reason :: put_ref_reason, state :: any}
+
+  @typedoc ~S"""
+  Error codes that can be returned by `get_ref/2`.
+  """
+  @type get_ref_reason :: :invalid_name | :not_found
+
+  @doc ~S"""
+  Reads a reference from the repository.
+
+  If any existing reference exists with this name, it will be returned.
+
+  ## Parameters
+
+  `name` is the name of the reference to be found. It must be a valid name
+  as per `Xgit.Core.Ref.valid_name?/1`.
+
+  ## TO DO
+
+  Dereference?
+
+  ## Return Value
+
+  `{:ok, ref}` if the reference was found successfully. `ref` will be an
+  `Xgit.Core.Ref` struct.
+
+  `{:error, :invalid_name}` if `name` is not a valid ref name.
+
+  `{:error, :not_found}` if no such reference exists.
+  """
+  @spec get_ref(repository :: t, name :: String.t(), opts :: Keyword.t()) ::
+          {:ok, ref :: Ref.t()} | {:error, reason :: get_ref_reason}
+  def get_ref(repository, name, opts \\ [])
+      when is_pid(repository) and is_binary(name) and is_list(opts) do
+    if Ref.valid_name?(name) do
+      GenServer.call(repository, {:get_ref, name, []})
+    else
+      cover {:error, :invalid_name}
+    end
+  end
+
+  @doc ~S"""
+  Reads a reference from the repository.
+
+  Called when `get_ref/3` is called.
+
+  ## Return Value
+
+  Should return `{:ok, ref, state}` if the reference was found successfully.
+  `ref` must be an `Xgit.Core.Ref` struct.
+
+  Should return `{:error, :not_found, state}` if no such reference exists.
+  """
+  @callback handle_get_ref(state :: any, name :: String.t(), opts :: Keyword.t()) ::
+              {:ok, ref :: Xgit.Core.Ref.t(), state :: any}
+              | {:error, reason :: get_ref_reason, state :: any}
+
   @impl true
   def handle_call(:valid_repository?, _from, state), do: {:reply, :valid_repository, state}
 
@@ -236,6 +382,15 @@ defmodule Xgit.Repository do
 
   def handle_call({:put_loose_object, %Object{} = object}, _from, state),
     do: delegate_call_to(state, :handle_put_loose_object, [object])
+
+  def handle_call(:list_refs, _from, state),
+    do: delegate_call_to(state, :handle_list_refs, [])
+
+  def handle_call({:put_ref, %Ref{} = ref, opts}, _from, state),
+    do: delegate_call_to(state, :handle_put_ref, [ref, opts])
+
+  def handle_call({:get_ref, name, opts}, _from, state),
+    do: delegate_call_to(state, :handle_get_ref, [name, opts])
 
   def handle_call(message, _from, state) do
     Logger.warn("Repository received unrecognized call #{inspect(message)}")

--- a/lib/xgit/repository.ex
+++ b/lib/xgit/repository.ex
@@ -232,7 +232,6 @@ defmodule Xgit.Repository do
     do: GenServer.call(repository, :list_refs)
 
   @doc ~S"""
-  Lists
   Lists all references in the repository.
 
   Called when `list_refs/1` is called.
@@ -296,6 +295,10 @@ defmodule Xgit.Repository do
   Writes or updates a reference in the repository.
 
   Called when `put_ref/3` is called.
+
+  The implementation must validate that the referenced object exists and is of
+  type `commit`. It does not need to validate that the reference is otherwise
+  valid.
 
   ## Return Value
 

--- a/lib/xgit/repository/in_memory.ex
+++ b/lib/xgit/repository/in_memory.ex
@@ -65,4 +65,19 @@ defmodule Xgit.Repository.InMemory do
 
   defp maybe_read_object_content(%Object{content: content} = object),
     do: %{object | content: content |> ContentSource.stream() |> Enum.concat()}
+
+  @impl true
+  def handle_list_refs(state) do
+    cover {:error, :unimplemented, state}
+  end
+
+  @impl true
+  def handle_put_ref(state, _ref, _opts) do
+    cover {:error, :unimplemented, state}
+  end
+
+  @impl true
+  def handle_get_ref(state, _name, _opts) do
+    cover {:error, :unimplemented, state}
+  end
 end

--- a/lib/xgit/repository/in_memory.ex
+++ b/lib/xgit/repository/in_memory.ex
@@ -12,6 +12,7 @@ defmodule Xgit.Repository.InMemory do
 
   alias Xgit.Core.ContentSource
   alias Xgit.Core.Object
+  alias Xgit.Core.Ref
 
   @doc ~S"""
   Start an in-memory git repository.
@@ -28,7 +29,7 @@ defmodule Xgit.Repository.InMemory do
   def start_link(opts \\ []), do: Repository.start_link(__MODULE__, opts, opts)
 
   @impl true
-  def init(opts) when is_list(opts), do: cover({:ok, %{loose_objects: %{}}})
+  def init(opts) when is_list(opts), do: cover({:ok, %{loose_objects: %{}, refs: %{}}})
 
   @impl true
   def handle_has_all_object_ids?(%{loose_objects: objects} = state, object_ids) do
@@ -37,15 +38,19 @@ defmodule Xgit.Repository.InMemory do
   end
 
   @impl true
-  def handle_get_object(%{loose_objects: objects} = state, object_id) do
+  def handle_get_object(state, object_id) do
+    case get_object_imp(state, object_id) do
+      %Object{} = object -> {:ok, object, state}
+      nil -> {:error, :not_found, state}
+    end
+  end
+
+  defp get_object_imp(%{loose_objects: objects} = _state, object_id) do
     # Currently only checks for loose objects.
     # TO DO: Look for object in packs.
     # https://github.com/elixir-git/xgit/issues/52
 
-    case Map.get(objects, object_id) do
-      %Object{} = object -> {:ok, object, state}
-      nil -> {:error, :not_found, state}
-    end
+    Map.get(objects, object_id)
   end
 
   @impl true
@@ -67,17 +72,26 @@ defmodule Xgit.Repository.InMemory do
     do: %{object | content: content |> ContentSource.stream() |> Enum.concat()}
 
   @impl true
-  def handle_list_refs(state) do
-    cover {:error, :unimplemented, state}
+  def handle_list_refs(%{refs: refs} = state) do
+    cover {:ok, refs |> Map.values() |> Enum.sort(), state}
   end
 
   @impl true
-  def handle_put_ref(state, _ref, _opts) do
-    cover {:error, :unimplemented, state}
+  def handle_put_ref(%{refs: refs} = state, %Ref{target: target} = ref, _opts) do
+    with {:object, %Object{} = object} <- {:object, get_object_imp(state, target)},
+         {:type, %{type: :commit}} <- {:type, object} do
+      cover {:ok, %{state | refs: Map.put(refs, ref.name, ref)}}
+    else
+      {:object, nil} -> cover {:error, :target_not_found, state}
+      {:type, _} -> cover {:error, :target_not_commit, state}
+    end
   end
 
   @impl true
-  def handle_get_ref(state, _name, _opts) do
-    cover {:error, :unimplemented, state}
+  def handle_get_ref(%{refs: refs} = state, name, _opts) do
+    case Map.get(refs, name) do
+      %Ref{} = ref -> cover {:ok, ref, state}
+      nil -> cover {:error, :not_found, state}
+    end
   end
 end

--- a/lib/xgit/repository/in_memory.ex
+++ b/lib/xgit/repository/in_memory.ex
@@ -40,8 +40,8 @@ defmodule Xgit.Repository.InMemory do
   @impl true
   def handle_get_object(state, object_id) do
     case get_object_imp(state, object_id) do
-      %Object{} = object -> {:ok, object, state}
-      nil -> {:error, :not_found, state}
+      %Object{} = object -> cover {:ok, object, state}
+      nil -> cover {:error, :not_found, state}
     end
   end
 

--- a/lib/xgit/repository/on_disk.ex
+++ b/lib/xgit/repository/on_disk.ex
@@ -393,4 +393,19 @@ defmodule Xgit.Repository.OnDisk do
 
   defp deflate_and_write_bytes(file, z, bytes, flush \\ :none),
     do: IO.binwrite(file, :zlib.deflate(z, bytes, flush))
+
+  @impl true
+  def handle_list_refs(state) do
+    cover {:error, :unimplemented, state}
+  end
+
+  @impl true
+  def handle_put_ref(state, _ref, _opts) do
+    cover {:error, :unimplemented, state}
+  end
+
+  @impl true
+  def handle_get_ref(state, _name, _opts) do
+    cover {:error, :unimplemented, state}
+  end
 end

--- a/lib/xgit/repository/on_disk.ex
+++ b/lib/xgit/repository/on_disk.ex
@@ -427,6 +427,7 @@ defmodule Xgit.Repository.OnDisk do
     with {:object, %Object{} = object} <- {:object, get_object_imp(state, target)},
          {:type, %{type: :commit}} <- {:type, object},
          :ok <- put_ref_imp(git_dir, ref) do
+      # TO DO: Update ref log if so requested. https://github.com/elixir-git/xgit/issues/224
       cover {:ok, state}
     else
       {:object, {:error, :not_found}} -> cover {:error, :target_not_found, state}

--- a/lib/xgit/repository/on_disk.ex
+++ b/lib/xgit/repository/on_disk.ex
@@ -405,6 +405,7 @@ defmodule Xgit.Repository.OnDisk do
     refs_dir = Path.join(git_dir, "refs")
 
     # TO DO: Add support for packed refs.
+    # https://github.com/elixir-git/xgit/issues/223
 
     {:ok,
      refs_dir

--- a/lib/xgit/repository/on_disk.ex
+++ b/lib/xgit/repository/on_disk.ex
@@ -438,10 +438,12 @@ defmodule Xgit.Repository.OnDisk do
     ref_path = Path.join(git_dir, name)
     ref_dir = Path.dirname(ref_path)
 
-    with :ok <- File.mkdir_p(ref_dir) do
+    mkdir_result = File.mkdir_p(ref_dir)
+
+    if mkdir_result == :ok do
       File.write(ref_path, "#{target}\n")
     else
-      {:error, posix} -> cover {:error, posix}
+      cover mkdir_result
     end
   end
 

--- a/test/xgit/repository/in_memory/ref_test.exs
+++ b/test/xgit/repository/in_memory/ref_test.exs
@@ -1,0 +1,95 @@
+defmodule Xgit.Repository.InMemory.RefTest do
+  # We test all of the Ref-related tests together.
+
+  use ExUnit.Case, async: true
+
+  alias Xgit.Core.Object
+  alias Xgit.Core.Ref
+  alias Xgit.Plumbing.HashObject
+  alias Xgit.Repository
+  alias Xgit.Repository.InMemory
+
+  describe "ref APIs" do
+    test "list_refs/1 null case" do
+      {:ok, repo} = InMemory.start_link()
+      assert {:ok, []} = Repository.list_refs(repo)
+    end
+
+    test "get_ref/2 not_found case" do
+      {:ok, repo} = InMemory.start_link()
+      assert {:error, :not_found} = Repository.get_ref(repo, "refs/heads/master")
+    end
+
+    test "get_ref/2 invalid_name case" do
+      {:ok, repo} = InMemory.start_link()
+      assert {:error, :invalid_name} = Repository.get_ref(repo, "refs/../../heads/master")
+    end
+
+    test "put_ref/2: error object must exist" do
+      {:ok, repo} = InMemory.start_link()
+
+      assert {:error, :target_not_found} =
+               Repository.put_ref(repo, %Ref{
+                 name: "refs/heads/master",
+                 target: "532ad3cb2518ad13a91e717998a26a6028df0623"
+               })
+    end
+
+    @test_content 'test content\n'
+    @test_content_id "d670460b4b4aece5915caf5c68d12f560a9fe3e4"
+
+    test "put_ref: object exists, but is not a commit" do
+      {:ok, repo} = InMemory.start_link()
+
+      object = %Object{type: :blob, content: @test_content, size: 13, id: @test_content_id}
+      :ok = Repository.put_loose_object(repo, object)
+
+      assert {:error, :target_not_commit} =
+               Repository.put_ref(repo, %Ref{
+                 name: "refs/heads/master",
+                 target: @test_content_id
+               })
+    end
+
+    test "put_ref followed by list and get" do
+      {:ok, repo} = InMemory.start_link()
+
+      {:ok, commit_id_master} =
+        HashObject.run('shhh... not really a commit',
+          repo: repo,
+          type: :commit,
+          validate?: false,
+          write?: true
+        )
+
+      master_ref = %Ref{
+        name: "refs/heads/master",
+        target: commit_id_master
+      }
+
+      assert :ok = Repository.put_ref(repo, master_ref)
+
+      assert {:ok, [^master_ref]} = Repository.list_refs(repo)
+
+      {:ok, commit_id_other} =
+        HashObject.run('shhh... another fake commit',
+          repo: repo,
+          type: :commit,
+          validate?: false,
+          write?: true
+        )
+
+      other_ref = %Ref{
+        name: "refs/heads/other",
+        target: commit_id_other
+      }
+
+      assert :ok = Repository.put_ref(repo, other_ref)
+
+      assert {:ok, ^master_ref} = Repository.get_ref(repo, "refs/heads/master")
+      assert {:ok, ^other_ref} = Repository.get_ref(repo, "refs/heads/other")
+
+      assert {:ok, [^master_ref, ^other_ref]} = Repository.list_refs(repo)
+    end
+  end
+end

--- a/test/xgit/repository/in_memory/ref_test.exs
+++ b/test/xgit/repository/in_memory/ref_test.exs
@@ -25,6 +25,16 @@ defmodule Xgit.Repository.InMemory.RefTest do
       assert {:error, :invalid_name} = Repository.get_ref(repo, "refs/../../heads/master")
     end
 
+    test "put_ref/2: invalid reference" do
+      {:ok, repo} = InMemory.start_link()
+
+      assert {:error, :invalid_ref} =
+               Repository.put_ref(repo, %Ref{
+                 name: "refs/heads/master",
+                 target: "532ad3cb2518ad13a91e717998a26a6028df062"
+               })
+    end
+
     test "put_ref/2: error object must exist" do
       {:ok, repo} = InMemory.start_link()
 

--- a/test/xgit/repository/on_disk/ref_test.exs
+++ b/test/xgit/repository/on_disk/ref_test.exs
@@ -11,6 +11,8 @@ defmodule Xgit.Repository.OnDisk.RefTest do
 
   import FolderDiff
 
+  @env OnDiskRepoTestCase.sample_commit_env()
+
   describe "ref APIs" do
     test "list_refs/1 null case" do
       %{xgit_repo: repo} = OnDiskRepoTestCase.repo!()
@@ -62,7 +64,11 @@ defmodule Xgit.Repository.OnDisk.RefTest do
     test "get_ref/2 can read ref written by command-line git" do
       %{xgit_repo: repo, xgit_path: path} = OnDiskRepoTestCase.repo!()
 
-      assert {_, 0} = System.cmd("git", ["commit", "--allow-empty", "--message", "foo"], cd: path)
+      assert {_, 0} =
+               System.cmd("git", ["commit", "--allow-empty", "--message", "foo"],
+                 cd: path,
+                 env: @env
+               )
 
       {show_ref_output, 0} = System.cmd("git", ["show-ref", "master"], cd: path)
       {commit_id, _} = String.split_at(show_ref_output, 40)

--- a/test/xgit/repository/on_disk/ref_test.exs
+++ b/test/xgit/repository/on_disk/ref_test.exs
@@ -1,0 +1,250 @@
+defmodule Xgit.Repository.OnDisk.RefTest do
+  # We test all of the Ref-related tests together.
+
+  use ExUnit.Case, async: true
+
+  alias Xgit.Core.Object
+  alias Xgit.Core.Ref
+  alias Xgit.Plumbing.HashObject
+  alias Xgit.Repository
+  alias Xgit.Test.OnDiskRepoTestCase
+
+  describe "ref APIs" do
+    test "list_refs/1 null case" do
+      %{xgit_repo: repo} = OnDiskRepoTestCase.repo!()
+      assert {:ok, []} = Repository.list_refs(repo)
+    end
+
+    test "get_ref/2 not_found case" do
+      %{xgit_repo: repo} = OnDiskRepoTestCase.repo!()
+      assert {:error, :not_found} = Repository.get_ref(repo, "refs/heads/master")
+    end
+
+    test "get_ref/2 invalid_name case" do
+      %{xgit_repo: repo} = OnDiskRepoTestCase.repo!()
+      assert {:error, :invalid_name} = Repository.get_ref(repo, "refs/../../heads/master")
+    end
+
+    test "get_ref/2 invalid ref (malformed file)" do
+      %{xgit_repo: repo, xgit_path: xgit_path} = OnDiskRepoTestCase.repo!()
+
+      File.write!(Path.join(xgit_path, ".git/refs/heads/master"), "not a SHA-1 hash")
+
+      assert {:error, :invalid_ref} = Repository.get_ref(repo, "refs/heads/master")
+    end
+
+    test "get_ref/2 invalid ref (dir, not file)" do
+      %{xgit_repo: repo, xgit_path: xgit_path} = OnDiskRepoTestCase.repo!()
+
+      File.mkdir_p!(Path.join(xgit_path, ".git/refs/heads/master"))
+
+      assert {:error, :eisdir} = Repository.get_ref(repo, "refs/heads/master")
+    end
+
+    test "get_ref/2 invalid ref (empty file)" do
+      %{xgit_repo: repo, xgit_path: xgit_path} = OnDiskRepoTestCase.repo!()
+
+      File.write!(Path.join(xgit_path, ".git/refs/heads/master"), "")
+
+      assert {:error, :eof} = Repository.get_ref(repo, "refs/heads/master")
+    end
+
+    test "get_ref/2 posix error" do
+      %{xgit_repo: repo, xgit_path: xgit_path} = OnDiskRepoTestCase.repo!()
+
+      File.mkdir_p!(Path.join(xgit_path, ".git/refs/heads/master"))
+
+      assert {:error, :eisdir} = Repository.get_ref(repo, "refs/heads/master")
+    end
+
+    test "get_ref/2 can read ref written by command-line git" do
+      %{xgit_repo: repo, xgit_path: path} =
+        OnDiskRepoTestCase.repo!("/Users/scouten/Desktop/get_ref")
+
+      assert {_, 0} = System.cmd("git", ["commit", "--allow-empty", "--message", "foo"], cd: path)
+
+      {show_ref_output, 0} = System.cmd("git", ["show-ref", "master"], cd: path)
+      {commit_id, _} = String.split_at(show_ref_output, 40)
+
+      assert {_, 0} = System.cmd("git", ["update-ref", "refs/heads/other", commit_id], cd: path)
+
+      other_ref = %Ref{
+        name: "refs/heads/other",
+        target: commit_id
+      }
+
+      assert {:ok, ^other_ref} = Repository.get_ref(repo, "refs/heads/other")
+    end
+
+    test "put_ref/2 object must exist" do
+      %{xgit_repo: repo} = OnDiskRepoTestCase.repo!()
+
+      assert {:error, :target_not_found} =
+               Repository.put_ref(repo, %Ref{
+                 name: "refs/heads/master",
+                 target: "532ad3cb2518ad13a91e717998a26a6028df0623"
+               })
+    end
+
+    @test_content 'test content\n'
+    @test_content_id "d670460b4b4aece5915caf5c68d12f560a9fe3e4"
+
+    test "put_ref/2 object exists, but is not a commit" do
+      %{xgit_repo: repo} = OnDiskRepoTestCase.repo!()
+
+      object = %Object{type: :blob, content: @test_content, size: 13, id: @test_content_id}
+      :ok = Repository.put_loose_object(repo, object)
+
+      assert {:error, :target_not_commit} =
+               Repository.put_ref(repo, %Ref{
+                 name: "refs/heads/master",
+                 target: @test_content_id
+               })
+    end
+
+    test "put_ref/2 posix error (dir where file should be)" do
+      %{xgit_repo: repo, xgit_path: xgit_path} = OnDiskRepoTestCase.repo!()
+
+      File.mkdir_p!(Path.join(xgit_path, ".git/refs/heads/master"))
+
+      {:ok, commit_id_master} =
+        HashObject.run('shhh... not really a commit',
+          repo: repo,
+          type: :commit,
+          validate?: false,
+          write?: true
+        )
+
+      assert {:error, :eisdir} =
+               Repository.put_ref(repo, %Ref{
+                 name: "refs/heads/master",
+                 target: commit_id_master
+               })
+    end
+
+    test "put_ref/2 posix error (file where dir should be)" do
+      %{xgit_repo: repo, xgit_path: xgit_path} = OnDiskRepoTestCase.repo!()
+
+      File.write!(Path.join(xgit_path, ".git/refs/heads/sub"), "oops, not a directory")
+
+      {:ok, commit_id_master} =
+        HashObject.run('shhh... not really a commit',
+          repo: repo,
+          type: :commit,
+          validate?: false,
+          write?: true
+        )
+
+      assert {:error, :eexist} =
+               Repository.put_ref(repo, %Ref{
+                 name: "refs/heads/sub/master",
+                 target: commit_id_master
+               })
+    end
+
+    test "put_ref/2 followed by list and get" do
+      %{xgit_repo: repo} = OnDiskRepoTestCase.repo!()
+
+      {:ok, commit_id_master} =
+        HashObject.run('shhh... not really a commit',
+          repo: repo,
+          type: :commit,
+          validate?: false,
+          write?: true
+        )
+
+      master_ref = %Ref{
+        name: "refs/heads/master",
+        target: commit_id_master
+      }
+
+      assert :ok = Repository.put_ref(repo, master_ref)
+
+      assert {:ok, [^master_ref]} = Repository.list_refs(repo)
+
+      {:ok, commit_id_other} =
+        HashObject.run('shhh... another fake commit',
+          repo: repo,
+          type: :commit,
+          validate?: false,
+          write?: true
+        )
+
+      other_ref = %Ref{
+        name: "refs/heads/other",
+        target: commit_id_other
+      }
+
+      assert :ok = Repository.put_ref(repo, other_ref)
+
+      assert {:ok, ^master_ref} = Repository.get_ref(repo, "refs/heads/master")
+      assert {:ok, ^other_ref} = Repository.get_ref(repo, "refs/heads/other")
+
+      assert {:ok, [^master_ref, ^other_ref]} = Repository.list_refs(repo)
+    end
+
+    test "list_refs/1 skips malformed file" do
+      %{xgit_repo: repo, xgit_path: xgit_path} = OnDiskRepoTestCase.repo!()
+
+      {:ok, commit_id_master} =
+        HashObject.run('shhh... not really a commit',
+          repo: repo,
+          type: :commit,
+          validate?: false,
+          write?: true
+        )
+
+      master_ref = %Ref{
+        name: "refs/heads/master",
+        target: commit_id_master
+      }
+
+      assert :ok = Repository.put_ref(repo, master_ref)
+
+      File.write!(Path.join(xgit_path, ".git/refs/heads/other"), "not a SHA-1 hash")
+
+      assert {:ok, [^master_ref]} = Repository.list_refs(repo)
+    end
+
+    test "put_ref/2 can be read by command-line git" do
+      %{xgit_repo: repo, xgit_path: path} = OnDiskRepoTestCase.repo!()
+
+      {:ok, commit_id_master} =
+        HashObject.run('shhh... not really a commit',
+          repo: repo,
+          type: :commit,
+          validate?: false,
+          write?: true
+        )
+
+      master_ref = %Ref{
+        name: "refs/heads/master",
+        target: commit_id_master
+      }
+
+      assert :ok = Repository.put_ref(repo, master_ref)
+
+      {:ok, commit_id_other} =
+        HashObject.run('shhh... another fake commit',
+          repo: repo,
+          type: :commit,
+          validate?: false,
+          write?: true
+        )
+
+      other_ref = %Ref{
+        name: "refs/heads/other",
+        target: commit_id_other
+      }
+
+      assert :ok = Repository.put_ref(repo, other_ref)
+
+      show_ref_output = ~s"""
+      #{commit_id_master} refs/heads/master
+      #{commit_id_other} refs/heads/other
+      """
+
+      assert {^show_ref_output, 0} = System.cmd("git", ["show-ref"], cd: path)
+    end
+  end
+end

--- a/test/xgit/repository/on_disk/ref_test.exs
+++ b/test/xgit/repository/on_disk/ref_test.exs
@@ -60,8 +60,7 @@ defmodule Xgit.Repository.OnDisk.RefTest do
     end
 
     test "get_ref/2 can read ref written by command-line git" do
-      %{xgit_repo: repo, xgit_path: path} =
-        OnDiskRepoTestCase.repo!("/Users/scouten/Desktop/get_ref")
+      %{xgit_repo: repo, xgit_path: path} = OnDiskRepoTestCase.repo!()
 
       assert {_, 0} = System.cmd("git", ["commit", "--allow-empty", "--message", "foo"], cd: path)
 


### PR DESCRIPTION
## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] There is test coverage for all changes.
- [x] All cases where a literal value is returned use the `cover` macro to force code coverage.
- ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
