### PR TITLE
Xgit.Repository.put_ref/3: Add `old_value` option.

### DIFF
--- a/lib/xgit/repository/in_memory.ex
+++ b/lib/xgit/repository/in_memory.ex
@@ -94,13 +94,8 @@ defmodule Xgit.Repository.InMemory do
 
   defp old_target_matches?(refs, %{name: name} = _new_ref, :new), do: not Map.has_key?(refs, name)
 
-  defp old_target_matches?(refs, %{name: name} = _new_ref, old_target) do
-    with %Ref{target: ^old_target} <- Map.get(refs, name) do
-      true
-    else
-      _ -> false
-    end
-  end
+  defp old_target_matches?(refs, %{name: name} = _new_ref, old_target),
+    do: match?(%Ref{target: ^old_target}, Map.get(refs, name))
 
   @impl true
   def handle_get_ref(%{refs: refs} = state, name, _opts) do

--- a/test/xgit/repository/in_memory/ref_test.exs
+++ b/test/xgit/repository/in_memory/ref_test.exs
@@ -101,5 +101,177 @@ defmodule Xgit.Repository.InMemory.RefTest do
 
       assert {:ok, [^master_ref, ^other_ref]} = Repository.list_refs(repo)
     end
+
+    test "put_ref: :old_target (correct match)" do
+      {:ok, repo} = InMemory.start_link()
+
+      {:ok, commit_id_master} =
+        HashObject.run('shhh... not really a commit',
+          repo: repo,
+          type: :commit,
+          validate?: false,
+          write?: true
+        )
+
+      master_ref = %Ref{
+        name: "refs/heads/master",
+        target: commit_id_master
+      }
+
+      assert :ok = Repository.put_ref(repo, master_ref)
+      assert {:ok, [^master_ref]} = Repository.list_refs(repo)
+
+      {:ok, commit_id2_master} =
+        HashObject.run('shhh... another not commit',
+          repo: repo,
+          type: :commit,
+          validate?: false,
+          write?: true
+        )
+
+      master_ref2 = %Ref{
+        name: "refs/heads/master",
+        target: commit_id2_master
+      }
+
+      assert :ok = Repository.put_ref(repo, master_ref2, old_target: commit_id_master)
+      assert {:ok, [^master_ref2]} = Repository.list_refs(repo)
+    end
+
+    test "put_ref: :old_target (incorrect match)" do
+      {:ok, repo} = InMemory.start_link()
+
+      {:ok, commit_id_master} =
+        HashObject.run('shhh... not really a commit',
+          repo: repo,
+          type: :commit,
+          validate?: false,
+          write?: true
+        )
+
+      master_ref = %Ref{
+        name: "refs/heads/master",
+        target: commit_id_master
+      }
+
+      assert :ok = Repository.put_ref(repo, master_ref)
+      assert {:ok, [^master_ref]} = Repository.list_refs(repo)
+
+      {:ok, commit_id2_master} =
+        HashObject.run('shhh... another not commit',
+          repo: repo,
+          type: :commit,
+          validate?: false,
+          write?: true
+        )
+
+      master_ref2 = %Ref{
+        name: "refs/heads/master",
+        target: commit_id2_master
+      }
+
+      assert {:error, :old_target_not_matched} =
+               Repository.put_ref(repo, master_ref2,
+                 old_target: "2075df9dff2b5a10ad417586b4edde66af849bad"
+               )
+
+      assert {:ok, [^master_ref]} = Repository.list_refs(repo)
+    end
+
+    test "put_ref: :old_target (does not exist)" do
+      {:ok, repo} = InMemory.start_link()
+
+      {:ok, commit_id_master} =
+        HashObject.run('shhh... not really a commit',
+          repo: repo,
+          type: :commit,
+          validate?: false,
+          write?: true
+        )
+
+      master_ref = %Ref{
+        name: "refs/heads/master",
+        target: commit_id_master
+      }
+
+      assert :ok = Repository.put_ref(repo, master_ref)
+      assert {:ok, [^master_ref]} = Repository.list_refs(repo)
+
+      {:ok, commit_id2_master} =
+        HashObject.run('shhh... another not commit',
+          repo: repo,
+          type: :commit,
+          validate?: false,
+          write?: true
+        )
+
+      master_ref2 = %Ref{
+        name: "refs/heads/master2",
+        target: commit_id2_master
+      }
+
+      assert {:error, :old_target_not_matched} =
+               Repository.put_ref(repo, master_ref2, old_target: commit_id_master)
+
+      assert {:ok, [^master_ref]} = Repository.list_refs(repo)
+    end
+
+    test "put_ref: :old_target = :new" do
+      {:ok, repo} = InMemory.start_link()
+
+      {:ok, commit_id_master} =
+        HashObject.run('shhh... not really a commit',
+          repo: repo,
+          type: :commit,
+          validate?: false,
+          write?: true
+        )
+
+      master_ref = %Ref{
+        name: "refs/heads/master",
+        target: commit_id_master
+      }
+
+      assert :ok = Repository.put_ref(repo, master_ref, old_target: :new)
+      assert {:ok, [^master_ref]} = Repository.list_refs(repo)
+    end
+
+    test "put_ref: :old_target = :new, but target does exist" do
+      {:ok, repo} = InMemory.start_link()
+
+      {:ok, commit_id_master} =
+        HashObject.run('shhh... not really a commit',
+          repo: repo,
+          type: :commit,
+          validate?: false,
+          write?: true
+        )
+
+      master_ref = %Ref{
+        name: "refs/heads/master",
+        target: commit_id_master
+      }
+
+      assert :ok = Repository.put_ref(repo, master_ref)
+      assert {:ok, [^master_ref]} = Repository.list_refs(repo)
+
+      {:ok, commit_id2_master} =
+        HashObject.run('shhh... another not commit',
+          repo: repo,
+          type: :commit,
+          validate?: false,
+          write?: true
+        )
+
+      master_ref2 = %Ref{
+        name: "refs/heads/master",
+        target: commit_id2_master
+      }
+
+      assert {:error, :old_target_not_matched} =
+               Repository.put_ref(repo, master_ref2, old_target: :new)
+
+      assert {:ok, [^master_ref]} = Repository.list_refs(repo)
+    end
   end
 end

--- a/test/xgit/repository/on_disk/ref_test.exs
+++ b/test/xgit/repository/on_disk/ref_test.exs
@@ -270,5 +270,177 @@ defmodule Xgit.Repository.OnDisk.RefTest do
         Path.join([xgit_path, ".git", "refs"])
       )
     end
+
+    test "put_ref: :old_target (correct match)" do
+      %{xgit_repo: repo} = OnDiskRepoTestCase.repo!()
+
+      {:ok, commit_id_master} =
+        HashObject.run('shhh... not really a commit',
+          repo: repo,
+          type: :commit,
+          validate?: false,
+          write?: true
+        )
+
+      master_ref = %Ref{
+        name: "refs/heads/master",
+        target: commit_id_master
+      }
+
+      assert :ok = Repository.put_ref(repo, master_ref)
+      assert {:ok, [^master_ref]} = Repository.list_refs(repo)
+
+      {:ok, commit_id2_master} =
+        HashObject.run('shhh... another not commit',
+          repo: repo,
+          type: :commit,
+          validate?: false,
+          write?: true
+        )
+
+      master_ref2 = %Ref{
+        name: "refs/heads/master",
+        target: commit_id2_master
+      }
+
+      assert :ok = Repository.put_ref(repo, master_ref2, old_target: commit_id_master)
+      assert {:ok, [^master_ref2]} = Repository.list_refs(repo)
+    end
+
+    test "put_ref: :old_target (incorrect match)" do
+      %{xgit_repo: repo} = OnDiskRepoTestCase.repo!()
+
+      {:ok, commit_id_master} =
+        HashObject.run('shhh... not really a commit',
+          repo: repo,
+          type: :commit,
+          validate?: false,
+          write?: true
+        )
+
+      master_ref = %Ref{
+        name: "refs/heads/master",
+        target: commit_id_master
+      }
+
+      assert :ok = Repository.put_ref(repo, master_ref)
+      assert {:ok, [^master_ref]} = Repository.list_refs(repo)
+
+      {:ok, commit_id2_master} =
+        HashObject.run('shhh... another not commit',
+          repo: repo,
+          type: :commit,
+          validate?: false,
+          write?: true
+        )
+
+      master_ref2 = %Ref{
+        name: "refs/heads/master",
+        target: commit_id2_master
+      }
+
+      assert {:error, :old_target_not_matched} =
+               Repository.put_ref(repo, master_ref2,
+                 old_target: "2075df9dff2b5a10ad417586b4edde66af849bad"
+               )
+
+      assert {:ok, [^master_ref]} = Repository.list_refs(repo)
+    end
+
+    test "put_ref: :old_target (does not exist)" do
+      %{xgit_repo: repo} = OnDiskRepoTestCase.repo!()
+
+      {:ok, commit_id_master} =
+        HashObject.run('shhh... not really a commit',
+          repo: repo,
+          type: :commit,
+          validate?: false,
+          write?: true
+        )
+
+      master_ref = %Ref{
+        name: "refs/heads/master",
+        target: commit_id_master
+      }
+
+      assert :ok = Repository.put_ref(repo, master_ref)
+      assert {:ok, [^master_ref]} = Repository.list_refs(repo)
+
+      {:ok, commit_id2_master} =
+        HashObject.run('shhh... another not commit',
+          repo: repo,
+          type: :commit,
+          validate?: false,
+          write?: true
+        )
+
+      master_ref2 = %Ref{
+        name: "refs/heads/master2",
+        target: commit_id2_master
+      }
+
+      assert {:error, :old_target_not_matched} =
+               Repository.put_ref(repo, master_ref2, old_target: commit_id_master)
+
+      assert {:ok, [^master_ref]} = Repository.list_refs(repo)
+    end
+
+    test "put_ref: :old_target = :new" do
+      %{xgit_repo: repo} = OnDiskRepoTestCase.repo!()
+
+      {:ok, commit_id_master} =
+        HashObject.run('shhh... not really a commit',
+          repo: repo,
+          type: :commit,
+          validate?: false,
+          write?: true
+        )
+
+      master_ref = %Ref{
+        name: "refs/heads/master",
+        target: commit_id_master
+      }
+
+      assert :ok = Repository.put_ref(repo, master_ref, old_target: :new)
+      assert {:ok, [^master_ref]} = Repository.list_refs(repo)
+    end
+
+    test "put_ref: :old_target = :new, but target does exist" do
+      %{xgit_repo: repo} = OnDiskRepoTestCase.repo!()
+
+      {:ok, commit_id_master} =
+        HashObject.run('shhh... not really a commit',
+          repo: repo,
+          type: :commit,
+          validate?: false,
+          write?: true
+        )
+
+      master_ref = %Ref{
+        name: "refs/heads/master",
+        target: commit_id_master
+      }
+
+      assert :ok = Repository.put_ref(repo, master_ref)
+      assert {:ok, [^master_ref]} = Repository.list_refs(repo)
+
+      {:ok, commit_id2_master} =
+        HashObject.run('shhh... another not commit',
+          repo: repo,
+          type: :commit,
+          validate?: false,
+          write?: true
+        )
+
+      master_ref2 = %Ref{
+        name: "refs/heads/master",
+        target: commit_id2_master
+      }
+
+      assert {:error, :old_target_not_matched} =
+               Repository.put_ref(repo, master_ref2, old_target: :new)
+
+      assert {:ok, [^master_ref]} = Repository.list_refs(repo)
+    end
   end
 end


### PR DESCRIPTION
## Changes in This Pull Request
This PR adds an `old_value` option to match the `oldvalue` parameter on `git update-ref`.

Closes #225.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] There is test coverage for all changes.
- [x] All cases where a literal value is returned use the `cover` macro to force code coverage.
- ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
