### PR TITLE
Xgit.Repository.InMemory should have a HEAD reference by default.

### DIFF
--- a/lib/xgit/repository.ex
+++ b/lib/xgit/repository.ex
@@ -430,12 +430,15 @@ defmodule Xgit.Repository do
           {:ok, ref :: Ref.t()} | {:error, reason :: get_ref_reason}
   def get_ref(repository, name, opts \\ [])
       when is_pid(repository) and is_binary(name) and is_list(opts) do
-    if Ref.valid_name?(name) do
+    if valid_ref_name?(name) do
       GenServer.call(repository, {:get_ref, name, []})
     else
       cover {:error, :invalid_name}
     end
   end
+
+  defp valid_ref_name?("HEAD"), do: cover(true)
+  defp valid_ref_name?(name), do: Ref.valid_name?(name)
 
   @doc ~S"""
   Reads a reference from the repository.

--- a/test/xgit/repository/in_memory/ref_test.exs
+++ b/test/xgit/repository/in_memory/ref_test.exs
@@ -10,6 +10,13 @@ defmodule Xgit.Repository.InMemory.RefTest do
   alias Xgit.Repository.InMemory
 
   describe "ref APIs" do
+    test "default repo contains HEAD reference" do
+      {:ok, repo} = InMemory.start_link()
+
+      assert {:ok, %Xgit.Core.Ref{name: "HEAD", target: "ref: refs/heads/master"}} =
+               Repository.get_ref(repo, "HEAD")
+    end
+
     test "list_refs/1 null case" do
       {:ok, repo} = InMemory.start_link()
       assert {:ok, []} = Repository.list_refs(repo)


### PR DESCRIPTION
## Checklist
- [x] This PR represents a single feature, fix, or change.
- ~All applicable changes have been documented.~ _n/a_
- [x] There is test coverage for all changes.
- [x] All cases where a literal value is returned use the `cover` macro to force code coverage.
- ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
