### PR TITLE
Xgit.Core.Ref: Add special case to allow the name "HEAD".

### DIFF
--- a/lib/xgit/core/ref.ex
+++ b/lib/xgit/core/ref.ex
@@ -77,6 +77,7 @@ defmodule Xgit.Core.Ref do
   def valid?(_, _opts), do: cover(false)
 
   defp valid_name?("@", _, _), do: cover(false)
+  defp valid_name?("HEAD", _, _), do: cover(true)
 
   defp valid_name?(name, true, false) do
     all_components_valid?(name) && not Regex.match?(~r/[\x00-\x20\\\?\[:^\x7E\x7F]/, name) &&

--- a/test/xgit/core/ref_test.exs
+++ b/test/xgit/core/ref_test.exs
@@ -4,7 +4,10 @@ defmodule Xgit.Core.RefTest do
   alias Xgit.Core.Ref
 
   defp assert_valid_name(name, opts \\ []) do
-    assert {_, 0} = System.cmd("git", check_ref_format_args(name, opts))
+    unless name == "HEAD" do
+      assert {_, 0} = System.cmd("git", check_ref_format_args(name, opts))
+    end
+
     assert Ref.valid?(%Ref{name: name, target: "155b7b4b7a6b798725df04a6cfcfb1aa042f0834"}, opts)
 
     if Enum.empty?(opts) && String.starts_with?(name, "refs/") do
@@ -39,6 +42,11 @@ defmodule Xgit.Core.RefTest do
   describe "valid?/1 name" do
     # From documentation for git check-ref-format
     # (https://git-scm.com/docs/git-check-ref-format):
+
+    test "HEAD" do
+      assert_valid_name("HEAD")
+      refute_valid_name("HEADx")
+    end
 
     # "Git imposes the following rules on how references are named:"
 


### PR DESCRIPTION
## Changes in This Pull Request
An `Xgit.Core.Ref` struct is considered valid if `name` == `"HEAD"`.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- ~All applicable changes have been documented.~ _n/a_
- [x] There is test coverage for all changes.
- [x] All cases where a literal value is returned use the `cover` macro to force code coverage.
- ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
