### PR TITLE
Fix incorrect typespec for Xgit.Core.Ref.

### DIFF
--- a/lib/xgit/core/ref.ex
+++ b/lib/xgit/core/ref.ex
@@ -39,7 +39,7 @@ defmodule Xgit.Core.Ref do
   @type t :: %__MODULE__{
           name: name(),
           target: target(),
-          link_target: name()
+          link_target: name() | nil
         }
 
   @enforce_keys [:name, :target]


### PR DESCRIPTION
## Changes in This Pull Request
Noticed while working on downstream code: `Xgit.Core.Ref` spec did not allow for `link_target` to be `nil`.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] There is test coverage for all changes.
- [x] All cases where a literal value is returned use the `cover` macro to force code coverage.
- ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
