### PR TITLE
Implement Xgit.Plumbing.UpdateRef.

### DIFF
--- a/lib/xgit/plumbing/update_ref.ex
+++ b/lib/xgit/plumbing/update_ref.ex
@@ -1,0 +1,92 @@
+defmodule Xgit.Plumbing.UpdateRef do
+  @moduledoc ~S"""
+  Update the object name stored in a ref.
+
+  Analogous to
+  [`git update-ref`](https://git-scm.com/docs/git-update-ref).
+  """
+
+  import Xgit.Util.ForceCoverage
+
+  alias Xgit.Core.ObjectId
+  alias Xgit.Core.Ref
+  alias Xgit.Repository
+
+  @typedoc ~S"""
+  Reason codes that can be returned by `run/2`.
+  """
+  @type reason :: :invalid_repository | Repository.put_ref_reason()
+
+  @doc ~S"""
+  Translates the current working tree, as reflected in its index file, to one or more
+  tree objects.
+
+  The working tree must be in a fully-merged state.
+
+  ## Parameters
+
+  `repository` is the `Xgit.Repository` (PID) to search for the object.
+
+  `name` is the name of the reference to update. (See `t/Xgit.Core.Ref.name`.)
+
+  `new_value` is the object ID to be written at this reference. (Use `Xgit.Core.ObjectId.zero/0` to delete the reference.)
+
+  ## Options
+
+  `old_target`: If present, a ref with this name must already exist and the `target`
+  value must match the object ID provided in this option. (There is a special value `:new`
+  which instead requires that the named ref must **not** exist.)
+
+  ## Return Value
+
+  `:ok` if written successfully.
+
+  `{:error, :invalid_repository}` if `repository` doesn't represent a valid
+  `Xgit.Repository` process.
+
+  Reason codes may also come from the following functions:
+
+  * `Xgit.Repository.put_ref/3`
+  * `Xgit.Repository.delete_ref/3`
+  """
+  @spec run(repository :: Repository.t(), name :: Ref.name(), new_value :: ObjectId.t(),
+          old_target: ObjectId.t()
+        ) :: :ok | {:error, reason}
+  def run(repository, name, new_value, opts \\ [])
+      when is_pid(repository) and is_binary(name) and is_binary(new_value) and is_list(opts) do
+    with {:repository_valid?, true} <- {:repository_valid?, Repository.valid?(repository)},
+         repo_opts <- validate_opts(opts) do
+      if new_value == ObjectId.zero() do
+        Repository.delete_ref(repository, name, repo_opts)
+      else
+        Repository.put_ref(repository, %Ref{name: name, target: new_value}, repo_opts)
+      end
+    else
+      {:repository_valid?, false} -> cover {:error, :invalid_repository}
+    end
+  end
+
+  defp validate_opts(opts) do
+    case validate_old_target(Keyword.get(opts, :old_target, nil)) do
+      nil -> cover []
+      old_target -> cover [{:old_target, old_target}]
+    end
+  end
+
+  defp validate_old_target(nil) do
+    cover nil
+  end
+
+  defp validate_old_target(:new) do
+    cover :new
+  end
+
+  defp validate_old_target(old_target) do
+    if ObjectId.valid?(old_target) do
+      cover old_target
+    else
+      raise ArgumentError,
+            "Xgit.Plumbing.UpdateRef.run/4: old_target #{inspect(old_target)} is invalid"
+    end
+  end
+end

--- a/lib/xgit/plumbing/update_ref.ex
+++ b/lib/xgit/plumbing/update_ref.ex
@@ -37,6 +37,11 @@ defmodule Xgit.Plumbing.UpdateRef do
   value must match the object ID provided in this option. (There is a special value `:new`
   which instead requires that the named ref must **not** exist.)
 
+  ## TO DO
+
+  Follow symbolic links, but only if they start with `refs/`.
+  (https://github.com/elixir-git/xgit/issues/241)
+
   ## Return Value
 
   `:ok` if written successfully.

--- a/test/xgit/plumbing/update_ref_test.exs
+++ b/test/xgit/plumbing/update_ref_test.exs
@@ -1,0 +1,543 @@
+defmodule Xgit.Plumbing.UpdateRefTest do
+  use ExUnit.Case, async: true
+
+  alias Xgit.Core.Object
+  alias Xgit.Core.ObjectId
+  alias Xgit.Core.Ref
+  alias Xgit.Plumbing.HashObject
+  alias Xgit.Plumbing.UpdateRef
+  alias Xgit.Repository
+  alias Xgit.Test.OnDiskRepoTestCase
+
+  import FolderDiff
+
+  @env OnDiskRepoTestCase.sample_commit_env()
+
+  describe "run/4" do
+    test "error: object does not exist" do
+      %{xgit_repo: repo} = OnDiskRepoTestCase.repo!()
+
+      assert {:error, :target_not_found} =
+               UpdateRef.run(
+                 repo,
+                 "refs/heads/master",
+                 "532ad3cb2518ad13a91e717998a26a6028df0623"
+               )
+    end
+
+    @test_content 'test content\n'
+    @test_content_id "d670460b4b4aece5915caf5c68d12f560a9fe3e4"
+
+    test "error: object exists, but is not a commit" do
+      %{xgit_repo: repo} = OnDiskRepoTestCase.repo!()
+
+      object = %Object{type: :blob, content: @test_content, size: 13, id: @test_content_id}
+      :ok = Repository.put_loose_object(repo, object)
+
+      assert {:error, :target_not_commit} =
+               UpdateRef.run(repo, "refs/heads/master", @test_content_id)
+    end
+
+    test "error: posix error (dir where file should be)" do
+      %{xgit_repo: repo, xgit_path: xgit_path} = OnDiskRepoTestCase.repo!()
+
+      File.mkdir_p!(Path.join(xgit_path, ".git/refs/heads/master"))
+
+      {:ok, commit_id_master} =
+        HashObject.run('shhh... not really a commit',
+          repo: repo,
+          type: :commit,
+          validate?: false,
+          write?: true
+        )
+
+      assert {:error, :eisdir} = UpdateRef.run(repo, "refs/heads/master", commit_id_master)
+    end
+
+    test "error: posix error (file where dir should be)" do
+      %{xgit_repo: repo, xgit_path: xgit_path} = OnDiskRepoTestCase.repo!()
+
+      File.write!(Path.join(xgit_path, ".git/refs/heads/sub"), "oops, not a directory")
+
+      {:ok, commit_id_master} =
+        HashObject.run('shhh... not really a commit',
+          repo: repo,
+          type: :commit,
+          validate?: false,
+          write?: true
+        )
+
+      assert {:error, :eexist} = UpdateRef.run(repo, "refs/heads/sub/master", commit_id_master)
+    end
+
+    test "happy path" do
+      %{xgit_repo: repo} = OnDiskRepoTestCase.repo!()
+
+      {:ok, commit_id_master} =
+        HashObject.run('shhh... not really a commit',
+          repo: repo,
+          type: :commit,
+          validate?: false,
+          write?: true
+        )
+
+      master_ref = %Ref{
+        name: "refs/heads/master",
+        target: commit_id_master
+      }
+
+      assert :ok = UpdateRef.run(repo, "refs/heads/master", commit_id_master)
+
+      assert {:ok, [^master_ref]} = Repository.list_refs(repo)
+
+      {:ok, commit_id_other} =
+        HashObject.run('shhh... another fake commit',
+          repo: repo,
+          type: :commit,
+          validate?: false,
+          write?: true
+        )
+
+      other_ref = %Ref{
+        name: "refs/heads/other",
+        target: commit_id_other
+      }
+
+      assert :ok = UpdateRef.run(repo, "refs/heads/other", commit_id_other)
+
+      assert {:ok, ^master_ref} = Repository.get_ref(repo, "refs/heads/master")
+      assert {:ok, ^other_ref} = Repository.get_ref(repo, "refs/heads/other")
+
+      assert {:ok, [^master_ref, ^other_ref]} = Repository.list_refs(repo)
+    end
+
+    test "follows HEAD reference" do
+      %{xgit_repo: repo} = OnDiskRepoTestCase.repo!()
+
+      {:ok, commit_id_master} =
+        HashObject.run('shhh... not really a commit',
+          repo: repo,
+          type: :commit,
+          validate?: false,
+          write?: true
+        )
+
+      master_ref = %Ref{
+        name: "refs/heads/master",
+        target: commit_id_master
+      }
+
+      master_ref_via_head = %Ref{
+        name: "HEAD",
+        target: commit_id_master,
+        link_target: "refs/heads/master"
+      }
+
+      assert :ok = UpdateRef.run(repo, "HEAD", commit_id_master)
+
+      assert {:ok, [^master_ref]} = Repository.list_refs(repo)
+      assert {:ok, ^master_ref} = Repository.get_ref(repo, "refs/heads/master")
+      assert {:ok, ^master_ref_via_head} = Repository.get_ref(repo, "HEAD")
+    end
+
+    test "result can be read by command-line git" do
+      %{xgit_repo: repo, xgit_path: path} = OnDiskRepoTestCase.repo!()
+
+      {:ok, commit_id_master} =
+        HashObject.run('shhh... not really a commit',
+          repo: repo,
+          type: :commit,
+          validate?: false,
+          write?: true
+        )
+
+      assert :ok = UpdateRef.run(repo, "refs/heads/master", commit_id_master)
+
+      {:ok, commit_id_other} =
+        HashObject.run('shhh... another fake commit',
+          repo: repo,
+          type: :commit,
+          validate?: false,
+          write?: true
+        )
+
+      assert :ok = UpdateRef.run(repo, "refs/heads/other", commit_id_other)
+
+      show_ref_output = ~s"""
+      #{commit_id_master} refs/heads/master
+      #{commit_id_other} refs/heads/other
+      """
+
+      assert {^show_ref_output, 0} = System.cmd("git", ["show-ref"], cd: path)
+    end
+
+    test "matches command-line output" do
+      %{xgit_path: xgit_path, xgit_repo: xgit_repo, parent_id: xgit_commit_id} =
+        OnDiskRepoTestCase.setup_with_valid_parent_commit!()
+
+      %{xgit_path: ref_path, parent_id: ref_commit_id} =
+        OnDiskRepoTestCase.setup_with_valid_parent_commit!()
+
+      {_, 0} = System.cmd("git", ["update-ref", "refs/heads/other", ref_commit_id], cd: ref_path)
+
+      :ok = UpdateRef.run(xgit_repo, "refs/heads/other", xgit_commit_id)
+
+      assert_folders_are_equal(
+        Path.join([ref_path, ".git", "refs"]),
+        Path.join([xgit_path, ".git", "refs"])
+      )
+    end
+
+    test ":old_target (correct match)" do
+      %{xgit_repo: repo} = OnDiskRepoTestCase.repo!()
+
+      {:ok, commit_id_master} =
+        HashObject.run('shhh... not really a commit',
+          repo: repo,
+          type: :commit,
+          validate?: false,
+          write?: true
+        )
+
+      master_ref = %Ref{
+        name: "refs/heads/master",
+        target: commit_id_master
+      }
+
+      assert :ok = UpdateRef.run(repo, "refs/heads/master", commit_id_master)
+      assert {:ok, [^master_ref]} = Repository.list_refs(repo)
+
+      {:ok, commit_id2_master} =
+        HashObject.run('shhh... another not commit',
+          repo: repo,
+          type: :commit,
+          validate?: false,
+          write?: true
+        )
+
+      master_ref2 = %Ref{
+        name: "refs/heads/master",
+        target: commit_id2_master
+      }
+
+      assert :ok =
+               UpdateRef.run(repo, "refs/heads/master", commit_id2_master,
+                 old_target: commit_id_master
+               )
+
+      assert {:ok, [^master_ref2]} = Repository.list_refs(repo)
+    end
+
+    test ":old_target (incorrect match)" do
+      %{xgit_repo: repo} = OnDiskRepoTestCase.repo!()
+
+      {:ok, commit_id_master} =
+        HashObject.run('shhh... not really a commit',
+          repo: repo,
+          type: :commit,
+          validate?: false,
+          write?: true
+        )
+
+      master_ref = %Ref{
+        name: "refs/heads/master",
+        target: commit_id_master
+      }
+
+      assert :ok = UpdateRef.run(repo, "refs/heads/master", commit_id_master)
+      assert {:ok, [^master_ref]} = Repository.list_refs(repo)
+
+      {:ok, commit_id2_master} =
+        HashObject.run('shhh... another not commit',
+          repo: repo,
+          type: :commit,
+          validate?: false,
+          write?: true
+        )
+
+      assert {:error, :old_target_not_matched} =
+               UpdateRef.run(repo, "refs/heads/master", commit_id2_master,
+                 old_target: "2075df9dff2b5a10ad417586b4edde66af849bad"
+               )
+
+      assert {:ok, [^master_ref]} = Repository.list_refs(repo)
+    end
+
+    test ":old_target (does not exist)" do
+      %{xgit_repo: repo} = OnDiskRepoTestCase.repo!()
+
+      {:ok, commit_id_master} =
+        HashObject.run('shhh... not really a commit',
+          repo: repo,
+          type: :commit,
+          validate?: false,
+          write?: true
+        )
+
+      master_ref = %Ref{
+        name: "refs/heads/master",
+        target: commit_id_master
+      }
+
+      assert :ok = UpdateRef.run(repo, "refs/heads/master", commit_id_master)
+      assert {:ok, [^master_ref]} = Repository.list_refs(repo)
+
+      {:ok, commit_id2_master} =
+        HashObject.run('shhh... another not commit',
+          repo: repo,
+          type: :commit,
+          validate?: false,
+          write?: true
+        )
+
+      assert {:error, :old_target_not_matched} =
+               UpdateRef.run(repo, "refs/heads/master2", commit_id2_master,
+                 old_target: commit_id_master
+               )
+
+      assert {:ok, [^master_ref]} = Repository.list_refs(repo)
+    end
+
+    test ":old_target = :new" do
+      %{xgit_repo: repo} = OnDiskRepoTestCase.repo!()
+
+      {:ok, commit_id_master} =
+        HashObject.run('shhh... not really a commit',
+          repo: repo,
+          type: :commit,
+          validate?: false,
+          write?: true
+        )
+
+      master_ref = %Ref{
+        name: "refs/heads/master",
+        target: commit_id_master
+      }
+
+      assert :ok = UpdateRef.run(repo, "refs/heads/master", commit_id_master, old_target: :new)
+      assert {:ok, [^master_ref]} = Repository.list_refs(repo)
+    end
+
+    test ":old_target = :new, but target does exist" do
+      %{xgit_repo: repo} = OnDiskRepoTestCase.repo!()
+
+      {:ok, commit_id_master} =
+        HashObject.run('shhh... not really a commit',
+          repo: repo,
+          type: :commit,
+          validate?: false,
+          write?: true
+        )
+
+      master_ref = %Ref{
+        name: "refs/heads/master",
+        target: commit_id_master
+      }
+
+      assert :ok = UpdateRef.run(repo, "refs/heads/master", commit_id_master)
+      assert {:ok, [^master_ref]} = Repository.list_refs(repo)
+
+      {:ok, commit_id2_master} =
+        HashObject.run('shhh... another not commit',
+          repo: repo,
+          type: :commit,
+          validate?: false,
+          write?: true
+        )
+
+      assert {:error, :old_target_not_matched} =
+               UpdateRef.run(repo, "refs/heads/master", commit_id2_master, old_target: :new)
+
+      assert {:ok, [^master_ref]} = Repository.list_refs(repo)
+    end
+
+    test "target 0000 removes an existing ref" do
+      %{xgit_repo: repo} = OnDiskRepoTestCase.repo!()
+
+      {:ok, commit_id_master} =
+        HashObject.run('shhh... not really a commit',
+          repo: repo,
+          type: :commit,
+          validate?: false,
+          write?: true
+        )
+
+      master_ref = %Ref{
+        name: "refs/heads/master",
+        target: commit_id_master
+      }
+
+      assert :ok = UpdateRef.run(repo, "refs/heads/master", commit_id_master)
+
+      assert {:ok, [^master_ref]} = Repository.list_refs(repo)
+
+      assert :ok = UpdateRef.run(repo, "refs/heads/master", ObjectId.zero())
+
+      assert {:error, :not_found} = Repository.get_ref(repo, "refs/heads/master")
+      assert {:ok, []} = Repository.list_refs(repo)
+    end
+
+    test "target 0000 quietly 'succeeds' if ref didn't exist" do
+      %{xgit_repo: repo} = OnDiskRepoTestCase.repo!()
+
+      assert {:ok, []} = Repository.list_refs(repo)
+
+      assert :ok = UpdateRef.run(repo, "refs/heads/master", ObjectId.zero())
+
+      assert {:error, :not_found} = Repository.get_ref(repo, "refs/heads/master")
+      assert {:ok, []} = Repository.list_refs(repo)
+    end
+
+    test "target 0000 error if name invalid" do
+      %{xgit_repo: repo} = OnDiskRepoTestCase.repo!()
+
+      assert {:ok, []} = Repository.list_refs(repo)
+
+      assert {:error, :invalid_ref} = UpdateRef.run(repo, "refs", ObjectId.zero())
+
+      assert {:error, :not_found} = Repository.get_ref(repo, "refs/heads/master")
+      assert {:ok, []} = Repository.list_refs(repo)
+    end
+
+    test "delete :old_target matches existing ref" do
+      %{xgit_repo: repo} = OnDiskRepoTestCase.repo!()
+
+      {:ok, commit_id_master} =
+        HashObject.run('shhh... not really a commit',
+          repo: repo,
+          type: :commit,
+          validate?: false,
+          write?: true
+        )
+
+      master_ref = %Ref{
+        name: "refs/heads/master",
+        target: commit_id_master
+      }
+
+      assert :ok = UpdateRef.run(repo, "refs/heads/master", commit_id_master)
+
+      assert {:ok, [^master_ref]} = Repository.list_refs(repo)
+
+      assert :ok =
+               UpdateRef.run(repo, "refs/heads/master", ObjectId.zero(),
+                 old_target: commit_id_master
+               )
+
+      assert {:error, :not_found} = Repository.get_ref(repo, "refs/heads/master")
+      assert {:ok, []} = Repository.list_refs(repo)
+    end
+
+    test "delete doesn't remove ref if :old_target doesn't match" do
+      %{xgit_repo: repo} = OnDiskRepoTestCase.repo!()
+
+      {:ok, commit_id_master} =
+        HashObject.run('shhh... not really a commit',
+          repo: repo,
+          type: :commit,
+          validate?: false,
+          write?: true
+        )
+
+      master_ref = %Ref{
+        name: "refs/heads/master",
+        target: commit_id_master
+      }
+
+      assert :ok = UpdateRef.run(repo, "refs/heads/master", commit_id_master)
+
+      assert {:ok, [^master_ref]} = Repository.list_refs(repo)
+
+      assert {:error, :old_target_not_matched} =
+               UpdateRef.run(repo, "refs/heads/master", ObjectId.zero(),
+                 old_target: "bec43c416143e6b8bf9a3b559260185757e1386b"
+               )
+
+      assert {:ok, ^master_ref} = Repository.get_ref(repo, "refs/heads/master")
+      assert {:ok, [^master_ref]} = Repository.list_refs(repo)
+    end
+
+    test "delete error if :old_target specified and no ref exists" do
+      %{xgit_repo: repo} = OnDiskRepoTestCase.repo!()
+
+      assert {:ok, []} = Repository.list_refs(repo)
+
+      assert {:error, :old_target_not_matched} =
+               UpdateRef.run(repo, "refs/heads/master", ObjectId.zero(),
+                 old_target: "bec43c416143e6b8bf9a3b559260185757e1386b"
+               )
+
+      assert {:error, :not_found} = Repository.get_ref(repo, "refs/heads/master")
+      assert {:ok, []} = Repository.list_refs(repo)
+    end
+
+    test "delete {:error, :cant_delete_file}" do
+      %{xgit_repo: repo, xgit_path: path} = OnDiskRepoTestCase.repo!()
+
+      bogus_ref_path = Path.join(path, ".git/refs/heads/bogus")
+
+      File.mkdir_p!(bogus_ref_path)
+
+      assert {:error, :cant_delete_file} =
+               UpdateRef.run(repo, "refs/heads/bogus", ObjectId.zero())
+
+      assert File.dir?(bogus_ref_path)
+    end
+
+    test "deletion is seen by command-line git" do
+      %{xgit_repo: repo, xgit_path: path} = OnDiskRepoTestCase.repo!()
+
+      assert {_, 0} =
+               System.cmd("git", ["commit", "--allow-empty", "--message", "foo"],
+                 cd: path,
+                 env: @env
+               )
+
+      {show_ref_output, 0} = System.cmd("git", ["show-ref", "master"], cd: path)
+      {commit_id, _} = String.split_at(show_ref_output, 40)
+
+      assert {_, 0} = System.cmd("git", ["update-ref", "refs/heads/other", commit_id], cd: path)
+      assert {_, 0} = System.cmd("git", ["show-ref", "refs/heads/other"], cd: path)
+
+      assert :ok = UpdateRef.run(repo, "refs/heads/other", ObjectId.zero())
+
+      assert {_, 1} = System.cmd("git", ["show-ref", "refs/heads/other"], cd: path)
+    end
+
+    test "error: repository invalid (not PID)" do
+      assert_raise FunctionClauseError, fn ->
+        UpdateRef.run(
+          "xgit repo",
+          "refs/heads/master",
+          "18a4a651653d7caebd3af9c05b0dc7ffa2cd0ae0"
+        )
+      end
+    end
+
+    test "error: repository invalid (PID, but not repo)" do
+      {:ok, not_repo} = GenServer.start_link(NotValid, nil)
+
+      assert {:error, :invalid_repository} =
+               UpdateRef.run(
+                 not_repo,
+                 "refs/heads/master",
+                 "18a4a651653d7caebd3af9c05b0dc7ffa2cd0ae0"
+               )
+    end
+
+    test "error: old_target invalid" do
+      %{xgit_repo: repo} = OnDiskRepoTestCase.repo!()
+
+      assert_raise ArgumentError,
+                   ~s(Xgit.Plumbing.UpdateRef.run/4: old_target "bogus" is invalid),
+                   fn ->
+                     UpdateRef.run(
+                       repo,
+                       "refs/heads/master",
+                       "18a4a651653d7caebd3af9c05b0dc7ffa2cd0ae0",
+                       old_target: "bogus"
+                     )
+                   end
+    end
+  end
+end


### PR DESCRIPTION
## Changes in This Pull Request
This is an API equivalent to [`git update-ref`](https://git-scm.com/docs/git-update-ref).

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] There is test coverage for all changes.
- [x] All cases where a literal value is returned use the `cover` macro to force code coverage.
- ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
