### PR TITLE
Xgit.Repository.InMemory: Remove a line of code that is unreachable.

### DIFF
--- a/lib/xgit/repository/in_memory.ex
+++ b/lib/xgit/repository/in_memory.ex
@@ -99,7 +99,6 @@ defmodule Xgit.Repository.InMemory do
     else
       {:object, nil} -> cover {:error, :target_not_found, state}
       {:type, _} -> cover {:error, :target_not_commit, state}
-      {:deref, nil} -> cover {:error, :invalid_ref, state}
       {:old_target_matches?, _} -> cover {:error, :old_target_not_matched, state}
     end
   end


### PR DESCRIPTION
## Changes in This Pull Request
I can't logically construct a way to get to this particular case, so why have it?

This returns Xgit to 100% code coverage.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- ~All applicable changes have been documented.~ _n/a_
- ~There is test coverage for all changes.~ _n/a_
- ~All cases where a literal value is returned use the `cover` macro to force code coverage.~ _n/a_
- ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
