### PR TITLE
[API BREAKING] Xgit.Repository.put_ref/4: Add :follow_link? option.

### DIFF
--- a/lib/xgit/repository.ex
+++ b/lib/xgit/repository.ex
@@ -265,6 +265,8 @@ defmodule Xgit.Repository do
 
   ## Options
 
+  `follow_link?`: (default: `true`) `true` to follow symbolic refs
+
   `old_target`: If present, a ref with this name must already exist and the `target`
   value must match the object ID provided in this option. (There is a special value `:new`
   which instead requires that the named ref must **not** exist.)
@@ -290,7 +292,7 @@ defmodule Xgit.Repository do
   `{:error, :old_target_not_matched}` if `old_target` was specified and the target ref points
   to a different object ID.
   """
-  @spec put_ref(repository :: t, ref :: Ref.t(), old_target: ObjectId.t()) ::
+  @spec put_ref(repository :: t, ref :: Ref.t(), follow_link?: boolean, old_target: ObjectId.t()) ::
           :ok | {:error, reason :: put_ref_reason}
   def put_ref(repository, %Ref{} = ref, opts \\ []) when is_pid(repository) and is_list(opts) do
     if Ref.valid?(ref) do
@@ -310,6 +312,8 @@ defmodule Xgit.Repository do
   valid.
 
   ## Options
+
+  `follow_link?`: (default: `true`) `true` to follow symbolic refs
 
   `old_target`: If present, a ref with this name must already exist and the `target`
   value must match the object ID provided in this option. (There is a special value `:new`
@@ -331,7 +335,10 @@ defmodule Xgit.Repository do
   Should return `{:error, :old_target_not_matched}` if `old_target` was specified and the
   target ref points to a different object ID.
   """
-  @callback handle_put_ref(state :: any, ref :: Ref.t(), old_target: ObjectId.t()) ::
+  @callback handle_put_ref(state :: any, ref :: Ref.t(),
+              follow_link?: boolean,
+              old_target: ObjectId.t()
+            ) ::
               {:ok, state :: any} | {:error, reason :: put_ref_reason, state :: any}
 
   @typedoc ~S"""
@@ -348,6 +355,8 @@ defmodule Xgit.Repository do
   value must match the object ID provided in this option.
 
   ## TO DO
+
+  `follow_link?` option. https://github.com/elixir-git/xgit/issues/249
 
   Support for ref log. https://github.com/elixir-git/xgit/issues/224
 

--- a/test/xgit/repository/on_disk/ref_test.exs
+++ b/test/xgit/repository/on_disk/ref_test.exs
@@ -150,6 +150,36 @@ defmodule Xgit.Repository.OnDisk.RefTest do
         Path.join([xgit_path, ".git", "refs"])
       )
     end
+
+    test "result matches command-line output (follow_link?: false)" do
+      %{xgit_path: xgit_path, xgit_repo: xgit_repo} = OnDiskRepoTestCase.repo!()
+      %{xgit_path: ref_path} = OnDiskRepoTestCase.repo!()
+
+      {_, 0} =
+        System.cmd("git", ["symbolic-ref", "refs/heads/link", "refs/heads/other"], cd: ref_path)
+
+      {_, 0} =
+        System.cmd("git", ["symbolic-ref", "refs/heads/link", "refs/heads/blah"], cd: ref_path)
+
+      :ok =
+        Repository.put_ref(
+          xgit_repo,
+          %Ref{name: "refs/heads/link", target: "ref: refs/heads/other"},
+          follow_link?: false
+        )
+
+      :ok =
+        Repository.put_ref(
+          xgit_repo,
+          %Ref{name: "refs/heads/link", target: "ref: refs/heads/blah"},
+          follow_link?: false
+        )
+
+      assert_folders_are_equal(
+        Path.join([ref_path, ".git", "refs"]),
+        Path.join([xgit_path, ".git", "refs"])
+      )
+    end
   end
 
   describe "list_refs/1" do


### PR DESCRIPTION
## Changes in This Pull Request
With `follow_link?: false`, it will be possible to update an existing symbolic ref.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] There is test coverage for all changes.
- [x] All cases where a literal value is returned use the `cover` macro to force code coverage.
- ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
