### PR TITLE
Implement Xgit.Plumbing.SymbolicRef.Put.

### DIFF
--- a/lib/xgit/plumbing/symbolic_ref/put.ex
+++ b/lib/xgit/plumbing/symbolic_ref/put.ex
@@ -1,0 +1,63 @@
+defmodule Xgit.Plumbing.SymbolicRef.Put do
+  @moduledoc ~S"""
+  Modify a symbolic ref in a repo.
+
+  Analogous to the two-argument form of
+  [`git symbolic-ref`](https://git-scm.com/docs/git-symbolic-ref).
+  """
+
+  import Xgit.Util.ForceCoverage
+
+  alias Xgit.Core.Ref
+  alias Xgit.Repository
+
+  @typedoc ~S"""
+  Reason codes that can be returned by `run/2`.
+  """
+  @type reason :: :invalid_repository | Repository.put_ref_reason()
+
+  @doc ~S"""
+  Creates or updates a symbolic ref to point at a specific branch.
+
+  ## Parameters
+
+  `repository` is the `Xgit.Repository` (PID) in which to create the symbolic reference.
+
+  `name` is the name of the symbolic reference to create or update. (See `t/Xgit.Core.Ref.name`.)
+
+  `new_target` is the name of the reference that should be targeted by this symbolic reference.
+  This reference need not exist.
+
+  ## Options
+
+  TO DO: Add option to specify ref log message.
+  https://github.com/elixir-git/xgit/issues/251
+
+  ## Return Value
+
+  `:ok` if written successfully.
+
+  `{:error, :invalid_repository}` if `repository` doesn't represent a valid
+  `Xgit.Repository` process.
+
+  Reason codes may also come from the following functions:
+
+  * `Xgit.Repository.put_ref/3`
+  """
+  @spec run(
+          repository :: Repository.t(),
+          name :: Ref.name(),
+          new_target :: Ref.name(),
+          opts :: Keyword.t()
+        ) :: :ok | {:error, reason}
+  def run(repository, name, new_target, opts \\ [])
+      when is_pid(repository) and is_binary(name) and is_binary(new_target) and is_list(opts) do
+    if Repository.valid?(repository) do
+      Repository.put_ref(repository, %Ref{name: name, target: "ref: #{new_target}"},
+        follow_link?: false
+      )
+    else
+      cover {:error, :invalid_repository}
+    end
+  end
+end

--- a/test/xgit/plumbing/symbolic_ref/put_test.exs
+++ b/test/xgit/plumbing/symbolic_ref/put_test.exs
@@ -118,7 +118,7 @@ defmodule Xgit.Plumbing.SymbolicRef.PutTest do
     test "error: repository invalid (PID, but not repo)" do
       {:ok, not_repo} = GenServer.start_link(NotValid, nil)
 
-      assert {:error, :invalid_repository} = UpdateRef.run(not_repo, "HEAD", "refs/heads/master")
+      assert {:error, :invalid_repository} = Put.run(not_repo, "HEAD", "refs/heads/master")
     end
   end
 end

--- a/test/xgit/plumbing/symbolic_ref/put_test.exs
+++ b/test/xgit/plumbing/symbolic_ref/put_test.exs
@@ -1,8 +1,6 @@
 defmodule Xgit.Plumbing.SymbolicRef.PutTest do
   use ExUnit.Case, async: true
 
-  # alias Xgit.Core.Object
-  # alias Xgit.Core.ObjectId
   alias Xgit.Core.Ref
   alias Xgit.Plumbing.HashObject
   alias Xgit.Plumbing.SymbolicRef.Put
@@ -12,8 +10,6 @@ defmodule Xgit.Plumbing.SymbolicRef.PutTest do
 
   import FolderDiff
 
-  # @env OnDiskRepoTestCase.sample_commit_env()
-
   describe "run/4" do
     test "happy path: target ref does not exist" do
       %{xgit_path: path, xgit_repo: repo} = OnDiskRepoTestCase.repo!()
@@ -22,9 +18,6 @@ defmodule Xgit.Plumbing.SymbolicRef.PutTest do
 
       assert {"refs/heads/nope\n", 0} = System.cmd("git", ["symbolic-ref", "HEAD"], cd: path)
     end
-
-    # @test_content 'test content\n'
-    # @test_content_id "d670460b4b4aece5915caf5c68d12f560a9fe3e4"
 
     test "error: posix error (dir where file should be)" do
       %{xgit_repo: repo, xgit_path: xgit_path} = OnDiskRepoTestCase.repo!()

--- a/test/xgit/plumbing/symbolic_ref/put_test.exs
+++ b/test/xgit/plumbing/symbolic_ref/put_test.exs
@@ -1,0 +1,131 @@
+defmodule Xgit.Plumbing.SymbolicRef.PutTest do
+  use ExUnit.Case, async: true
+
+  # alias Xgit.Core.Object
+  # alias Xgit.Core.ObjectId
+  alias Xgit.Core.Ref
+  alias Xgit.Plumbing.HashObject
+  alias Xgit.Plumbing.SymbolicRef.Put
+  alias Xgit.Plumbing.UpdateRef
+  alias Xgit.Repository
+  alias Xgit.Test.OnDiskRepoTestCase
+
+  import FolderDiff
+
+  # @env OnDiskRepoTestCase.sample_commit_env()
+
+  describe "run/4" do
+    test "happy path: target ref does not exist" do
+      %{xgit_path: path, xgit_repo: repo} = OnDiskRepoTestCase.repo!()
+
+      assert :ok = Put.run(repo, "HEAD", "refs/heads/nope")
+
+      assert {"refs/heads/nope\n", 0} = System.cmd("git", ["symbolic-ref", "HEAD"], cd: path)
+    end
+
+    # @test_content 'test content\n'
+    # @test_content_id "d670460b4b4aece5915caf5c68d12f560a9fe3e4"
+
+    test "error: posix error (dir where file should be)" do
+      %{xgit_repo: repo, xgit_path: xgit_path} = OnDiskRepoTestCase.repo!()
+
+      File.mkdir_p!(Path.join(xgit_path, ".git/refs/heads/whatever"))
+
+      assert {:error, :eisdir} = Put.run(repo, "refs/heads/whatever", "refs/heads/master")
+    end
+
+    test "error: posix error (file where dir should be)" do
+      %{xgit_repo: repo, xgit_path: xgit_path} = OnDiskRepoTestCase.repo!()
+
+      File.write!(Path.join(xgit_path, ".git/refs/heads/sub"), "oops, not a directory")
+
+      assert {:error, :eexist} = Put.run(repo, "refs/heads/sub/master", "refs/heads/master")
+    end
+
+    test "follows HEAD reference after it changes" do
+      %{xgit_repo: repo} = OnDiskRepoTestCase.repo!()
+
+      {:ok, commit_id_master} =
+        HashObject.run('shhh... not really a commit',
+          repo: repo,
+          type: :commit,
+          validate?: false,
+          write?: true
+        )
+
+      master_ref = %Ref{
+        name: "refs/heads/master",
+        target: commit_id_master
+      }
+
+      master_ref_via_head = %Ref{
+        name: "HEAD",
+        target: commit_id_master,
+        link_target: "refs/heads/master"
+      }
+
+      assert :ok = UpdateRef.run(repo, "HEAD", commit_id_master)
+
+      assert {:ok, [^master_ref]} = Repository.list_refs(repo)
+      assert {:ok, ^master_ref} = Repository.get_ref(repo, "refs/heads/master")
+      assert {:ok, ^master_ref_via_head} = Repository.get_ref(repo, "HEAD")
+
+      {:ok, commit_id_other} =
+        HashObject.run('shhh... another not commit',
+          repo: repo,
+          type: :commit,
+          validate?: false,
+          write?: true
+        )
+
+      other_ref = %Ref{
+        name: "refs/heads/other",
+        target: commit_id_other
+      }
+
+      other_ref_via_head = %Ref{
+        name: "HEAD",
+        target: commit_id_other,
+        link_target: "refs/heads/other"
+      }
+
+      assert :ok = Put.run(repo, "HEAD", "refs/heads/other")
+
+      assert :ok = UpdateRef.run(repo, "HEAD", commit_id_other)
+
+      assert {:ok, [^master_ref, ^other_ref]} = Repository.list_refs(repo)
+      assert {:ok, ^master_ref} = Repository.get_ref(repo, "refs/heads/master")
+      assert {:ok, ^other_ref_via_head} = Repository.get_ref(repo, "HEAD")
+    end
+
+    test "result can be read by command-line git" do
+      %{xgit_repo: repo, xgit_path: path} = OnDiskRepoTestCase.repo!()
+
+      assert :ok = Put.run(repo, "HEAD", "refs/heads/other")
+      assert {"refs/heads/other\n", 0} = System.cmd("git", ["symbolic-ref", "HEAD"], cd: path)
+    end
+
+    test "matches command-line output" do
+      %{xgit_path: xgit_path, xgit_repo: xgit_repo} = OnDiskRepoTestCase.repo!()
+      %{xgit_path: ref_path} = OnDiskRepoTestCase.repo!()
+
+      {_, 0} = System.cmd("git", ["symbolic-ref", "HEAD", "refs/heads/other"], cd: ref_path)
+
+      :ok = Put.run(xgit_repo, "HEAD", "refs/heads/other")
+
+      assert_folders_are_equal(ref_path, xgit_path)
+    end
+
+    test "error: repository invalid (not PID)" do
+      assert_raise FunctionClauseError, fn ->
+        Put.run("xgit repo", "HEAD", "refs/heads/master")
+      end
+    end
+
+    test "error: repository invalid (PID, but not repo)" do
+      {:ok, not_repo} = GenServer.start_link(NotValid, nil)
+
+      assert {:error, :invalid_repository} = UpdateRef.run(not_repo, "HEAD", "refs/heads/master")
+    end
+  end
+end


### PR DESCRIPTION
## Changes in This Pull Request
This is an API analogue to the 2-argument form of `git symbolic-ref`.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] There is test coverage for all changes.
- [x] All cases where a literal value is returned use the `cover` macro to force code coverage.
- ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
