### PR TITLE
Rename Xgit.Repository to Xgit.Repository.Storage.

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -21,7 +21,7 @@ Xgit.Core.Tree
 	from_object/1
 	to_object/1
 
-Xgit.Repository (permute on the implementations)
+Xgit.Repository.Storage (permute on the implementations)
 	get_object/2
 	has_all_object_ids?/2
 	put_loose_object/2

--- a/lib/xgit/README.md
+++ b/lib/xgit/README.md
@@ -7,10 +7,10 @@ arbitrary locations other than file systems. (In a server environment, it likely
 makes sense to store content in a database or cloud-based file system such as S3.)
 
 For that reason, the concept of **"repository"** in Xgit is kept intentionally
-minimal. `Xgit.Repository` defines a is a behaviour module that describes the interface
+minimal. `Xgit.Repository.Storage` defines a behaviour module that describes the interface
 that a storage implementor would need to implement and very little else. (A repository
 is implemented using `GenServer` so that it can maintain its state independently.
-`Xgit.Repository` provides a wrapper interface for the calls that other modules
+`Xgit.Repository.Storage` provides a wrapper interface for the calls that other modules
 within Xgit need to make to manipulate the repository.)
 
 A **typical end-user developer** will typically construct an instance of `Xgit.Repository.OnDisk`
@@ -21,7 +21,7 @@ extent possible.)
 
 A **storage architect** will construct a module that encapsulates the desired storage mechanism
 in a `GenServer` process and makes that available to the rest of Xgit by implementing
-the `Xgit.Repository` behaviour interface.
+the `Xgit.Repository.Storage` behaviour interface.
 
 **Guideline:** With the exception of the reference implementation `Xgit.Repository.OnDisk`,
 all code in Xgit should be implemented without knowledge of how and where content is stored.
@@ -52,3 +52,5 @@ of the dependency sequence:
 
 * **`util`**: The modules in this folder aren't really part of the data model
   _per se_, but provide building blocks to make higher layers of Xgit possible.
+  These are considered implementation details and not part of the public API of
+  Xgit.

--- a/lib/xgit/core/dir_cache.ex
+++ b/lib/xgit/core/dir_cache.ex
@@ -5,7 +5,7 @@ defmodule Xgit.Core.DirCache do
 
   In Xgit, the `DirCache` structure is an abstract, in-memory data structure
   without any tie to a specific persistence mechanism. Persistence is implemented
-  by a specific implementation of the `Xgit.Repository` behaviour.
+  by a specific implementation of the `Xgit.Repository.Storage` behaviour.
 
   This content is commonly persisted on disk as an `index` file at the root of
   the git tree. The module `Xgit.Repository.WorkingTree.ParseIndexFile` can

--- a/lib/xgit/plumbing/cat_file.ex
+++ b/lib/xgit/plumbing/cat_file.ex
@@ -10,7 +10,7 @@ defmodule Xgit.Plumbing.CatFile do
 
   alias Xgit.Core.Object
   alias Xgit.Core.ObjectId
-  alias Xgit.Repository
+  alias Xgit.Repository.Storage
 
   @typedoc ~S"""
   Reason codes that can be returned by `run/2`.
@@ -23,7 +23,7 @@ defmodule Xgit.Plumbing.CatFile do
 
   ## Parameters
 
-  `repository` is the `Xgit.Repository` (PID) to search for the object.
+  `repository` is the `Xgit.Repository.Storage` (PID) to search for the object.
 
   `object_id` is a string identifying the object.
 
@@ -34,7 +34,7 @@ defmodule Xgit.Plumbing.CatFile do
   about the underlying git object.
 
   `{:error, :invalid_repository}` if `repository` doesn't represent a valid
-  `Xgit.Repository` process.
+  `Xgit.Repository.Storage` process.
 
   `{:error, :invalid_object_id}` if `object_id` can't be parsed as a valid git object ID.
 
@@ -42,14 +42,14 @@ defmodule Xgit.Plumbing.CatFile do
 
   `{:error, :invalid_object}` if object was found, but invalid.
   """
-  @spec run(repository :: Repository.t(), object_id :: ObjectId.t()) ::
+  @spec run(repository :: Storage.t(), object_id :: ObjectId.t()) ::
           {:ok, Object}
           | {:error, reason :: reason}
-          | {:error, reason :: Repository.get_object_reason()}
+          | {:error, reason :: Storage.get_object_reason()}
   def run(repository, object_id) when is_pid(repository) and is_binary(object_id) do
-    with {:repository_valid?, true} <- {:repository_valid?, Repository.valid?(repository)},
+    with {:repository_valid?, true} <- {:repository_valid?, Storage.valid?(repository)},
          {:object_id_valid?, true} <- {:object_id_valid?, ObjectId.valid?(object_id)} do
-      Repository.get_object(repository, object_id)
+      Storage.get_object(repository, object_id)
     else
       {:repository_valid?, false} -> cover {:error, :invalid_repository}
       {:object_id_valid?, false} -> cover {:error, :invalid_object_id}

--- a/lib/xgit/plumbing/cat_file/commit.ex
+++ b/lib/xgit/plumbing/cat_file/commit.ex
@@ -10,7 +10,7 @@ defmodule Xgit.Plumbing.CatFile.Commit do
 
   alias Xgit.Core.Commit
   alias Xgit.Core.ObjectId
-  alias Xgit.Repository
+  alias Xgit.Repository.Storage
 
   @typedoc ~S"""
   Reason codes that can be returned by `run/2`.
@@ -18,8 +18,8 @@ defmodule Xgit.Plumbing.CatFile.Commit do
   @type reason ::
           :invalid_repository
           | :invalid_object_id
-          | Repository.get_object_reason()
           | Commit.from_object_reason()
+          | Storage.get_object_reason()
 
   @doc ~S"""
   Retrieves a `commit` object from a repository's object store and renders
@@ -27,7 +27,7 @@ defmodule Xgit.Plumbing.CatFile.Commit do
 
   ## Parameters
 
-  `repository` is the `Xgit.Repository` (PID) to search for the object.
+  `repository` is the `Xgit.Repository.Storage` (PID) to search for the object.
 
   `object_id` is a string identifying the object.
 
@@ -38,21 +38,21 @@ defmodule Xgit.Plumbing.CatFile.Commit do
   references to the members of that commit.
 
   `{:error, :invalid_repository}` if `repository` doesn't represent a valid
-  `Xgit.Repository` process.
+  `Xgit.Repository.Storage` process.
 
   `{:error, :invalid_object_id}` if `object_id` can't be parsed as a valid git object ID.
 
   `{:error, reason}` if otherwise unable. The relevant reason codes may come from:
 
   * `Xgit.Core.Commit.from_object/1`.
-  * `Xgit.Repository.get_object/2`
+  * `Xgit.Repository.Storage.get_object/2`
   """
-  @spec run(repository :: Repository.t(), object_id :: ObjectId.t()) ::
+  @spec run(repository :: Storage.t(), object_id :: ObjectId.t()) ::
           {:ok, commit :: Commit.t()} | {:error, reason :: reason}
   def run(repository, object_id) when is_pid(repository) and is_binary(object_id) do
-    with {:repository_valid?, true} <- {:repository_valid?, Repository.valid?(repository)},
+    with {:repository_valid?, true} <- {:repository_valid?, Storage.valid?(repository)},
          {:object_id_valid?, true} <- {:object_id_valid?, ObjectId.valid?(object_id)},
-         {:ok, object} <- Repository.get_object(repository, object_id) do
+         {:ok, object} <- Storage.get_object(repository, object_id) do
       Commit.from_object(object)
     else
       {:error, reason} -> cover {:error, reason}

--- a/lib/xgit/plumbing/cat_file/tree.ex
+++ b/lib/xgit/plumbing/cat_file/tree.ex
@@ -10,7 +10,7 @@ defmodule Xgit.Plumbing.CatFile.Tree do
 
   alias Xgit.Core.ObjectId
   alias Xgit.Core.Tree
-  alias Xgit.Repository
+  alias Xgit.Repository.Storage
 
   @typedoc ~S"""
   Reason codes that can be returned by `run/2`.
@@ -18,7 +18,7 @@ defmodule Xgit.Plumbing.CatFile.Tree do
   @type reason ::
           :invalid_repository
           | :invalid_object_id
-          | Repository.get_object_reason()
+          | Storage.get_object_reason()
           | Tree.from_object_reason()
 
   @doc ~S"""
@@ -27,7 +27,7 @@ defmodule Xgit.Plumbing.CatFile.Tree do
 
   ## Parameters
 
-  `repository` is the `Xgit.Repository` (PID) to search for the object.
+  `repository` is the `Xgit.Repository.Storage` (PID) to search for the object.
 
   `object_id` is a string identifying the object.
 
@@ -38,21 +38,21 @@ defmodule Xgit.Plumbing.CatFile.Tree do
   references to the members of that tree.
 
   `{:error, :invalid_repository}` if `repository` doesn't represent a valid
-  `Xgit.Repository` process.
+  `Xgit.Repository.Storage` process.
 
   `{:error, :invalid_object_id}` if `object_id` can't be parsed as a valid git object ID.
 
   `{:error, reason}` if otherwise unable. The relevant reason codes may come from:
 
   * `Xgit.Core.Tree.from_object/1`.
-  * `Xgit.Repository.get_object/2`
+  * `Xgit.Repository.Storage.get_object/2`
   """
-  @spec run(repository :: Repository.t(), object_id :: ObjectId.t()) ::
+  @spec run(repository :: Storage.t(), object_id :: ObjectId.t()) ::
           {:ok, tree :: Tree.t()} | {:error, reason :: reason}
   def run(repository, object_id) when is_pid(repository) and is_binary(object_id) do
-    with {:repository_valid?, true} <- {:repository_valid?, Repository.valid?(repository)},
+    with {:repository_valid?, true} <- {:repository_valid?, Storage.valid?(repository)},
          {:object_id_valid?, true} <- {:object_id_valid?, ObjectId.valid?(object_id)},
-         {:ok, object} <- Repository.get_object(repository, object_id) do
+         {:ok, object} <- Storage.get_object(repository, object_id) do
       Tree.from_object(object)
     else
       {:error, reason} -> cover {:error, reason}

--- a/lib/xgit/plumbing/ls_files/stage.ex
+++ b/lib/xgit/plumbing/ls_files/stage.ex
@@ -11,7 +11,7 @@ defmodule Xgit.Plumbing.LsFiles.Stage do
   alias Xgit.Core.DirCache
   alias Xgit.Core.DirCache.Entry, as: DirCacheEntry
   alias Xgit.Plumbing.Util.WorkingTreeOpt
-  alias Xgit.Repository
+  alias Xgit.Repository.Storage
   alias Xgit.Repository.WorkingTree
   alias Xgit.Repository.WorkingTree.ParseIndexFile
 
@@ -25,7 +25,7 @@ defmodule Xgit.Plumbing.LsFiles.Stage do
 
   ## Parameters
 
-  `repository` is the `Xgit.Repository` (PID) to search for the object.
+  `repository` is the `Xgit.Repository.Storage` (PID) to search for the object.
 
   ## Return Value
 
@@ -33,7 +33,7 @@ defmodule Xgit.Plumbing.LsFiles.Stage do
   in sorted order.
 
   `{:error, :invalid_repository}` if `repository` doesn't represent a valid
-  `Xgit.Repository` process.
+  `Xgit.Repository.Storage` process.
 
   `{:error, :bare}` if `repository` doesn't have a working tree.
 
@@ -41,7 +41,7 @@ defmodule Xgit.Plumbing.LsFiles.Stage do
   `Xgit.Repository.WorkingTree.ParseIndexFile.from_iodevice/1` for possible
   reason codes.)
   """
-  @spec run(repository :: Repository.t()) ::
+  @spec run(repository :: Storage.t()) ::
           {:ok, entries :: [DirCacheEntry.t()]}
           | {:error, reason :: reason}
   def run(repository) when is_pid(repository) do

--- a/lib/xgit/plumbing/read_tree.ex
+++ b/lib/xgit/plumbing/read_tree.ex
@@ -10,7 +10,7 @@ defmodule Xgit.Plumbing.ReadTree do
 
   alias Xgit.Core.ObjectId
   alias Xgit.Plumbing.Util.WorkingTreeOpt
-  alias Xgit.Repository
+  alias Xgit.Repository.Storage
   alias Xgit.Repository.WorkingTree
 
   @typedoc ~S"""
@@ -30,7 +30,7 @@ defmodule Xgit.Plumbing.ReadTree do
 
   ## Parameters
 
-  `repository` is the `Xgit.Repository` (PID) to search for the object.
+  `repository` is the `Xgit.Repository.Storage` (PID) to search for the object.
 
   `object_id` is the object ID of the root working tree. The special name `:empty`
   may be used to empty the index.
@@ -45,22 +45,22 @@ defmodule Xgit.Plumbing.ReadTree do
   `:ok` if successful.
 
   `{:error, :invalid_repository}` if `repository` doesn't represent a valid
-  `Xgit.Repository` process.
+  `Xgit.Repository.Storage` process.
 
   `{:error, :bare}` if `repository` doesn't have a working tree.
 
   Reason codes may also come from the following functions:
 
   * `Xgit.Core.Tree.from_object/1`
-  * `Xgit.Repository.get_object/2`
-  * `Xgit.Repository.WorkingTree.read_tree/3`
-  * `Xgit.Repository.WorkingTree.WriteIndexFile.to_iodevice/2`
+  * `Xgit.Repository.Storage.get_object/2`
+  * `Xgit.Repository.Storage.WorkingTree.read_tree/3`
+  * `Xgit.Repository.Storage.WorkingTree.WriteIndexFile.to_iodevice/2`
 
   ## TO DO
 
   Implement `--prefix` option. https://github.com/elixir-git/xgit/issues/175
   """
-  @spec run(repository :: Repository.t(), object_id :: ObjectId.t(), missing_ok?: boolean) ::
+  @spec run(repository :: Storage.t(), object_id :: ObjectId.t(), missing_ok?: boolean) ::
           :ok | {:error, reason :: reason}
   def run(repository, object_id, opts \\ [])
       when is_pid(repository) and (is_binary(object_id) or object_id == :empty) and is_list(opts) do

--- a/lib/xgit/plumbing/symbolic_ref/put.ex
+++ b/lib/xgit/plumbing/symbolic_ref/put.ex
@@ -9,19 +9,19 @@ defmodule Xgit.Plumbing.SymbolicRef.Put do
   import Xgit.Util.ForceCoverage
 
   alias Xgit.Core.Ref
-  alias Xgit.Repository
+  alias Xgit.Repository.Storage
 
   @typedoc ~S"""
   Reason codes that can be returned by `run/2`.
   """
-  @type reason :: :invalid_repository | Repository.put_ref_reason()
+  @type reason :: :invalid_repository | Storage.put_ref_reason()
 
   @doc ~S"""
   Creates or updates a symbolic ref to point at a specific branch.
 
   ## Parameters
 
-  `repository` is the `Xgit.Repository` (PID) in which to create the symbolic reference.
+  `repository` is the `Xgit.Repository.Storage` (PID) in which to create the symbolic reference.
 
   `name` is the name of the symbolic reference to create or update. (See `t/Xgit.Core.Ref.name`.)
 
@@ -38,22 +38,22 @@ defmodule Xgit.Plumbing.SymbolicRef.Put do
   `:ok` if written successfully.
 
   `{:error, :invalid_repository}` if `repository` doesn't represent a valid
-  `Xgit.Repository` process.
+  `Xgit.Repository.Storage` process.
 
   Reason codes may also come from the following functions:
 
-  * `Xgit.Repository.put_ref/3`
+  * `Xgit.Repository.Storage.put_ref/3`
   """
   @spec run(
-          repository :: Repository.t(),
+          repository :: Storage.t(),
           name :: Ref.name(),
           new_target :: Ref.name(),
           opts :: Keyword.t()
         ) :: :ok | {:error, reason}
   def run(repository, name, new_target, opts \\ [])
       when is_pid(repository) and is_binary(name) and is_binary(new_target) and is_list(opts) do
-    if Repository.valid?(repository) do
-      Repository.put_ref(repository, %Ref{name: name, target: "ref: #{new_target}"},
+    if Storage.valid?(repository) do
+      Storage.put_ref(repository, %Ref{name: name, target: "ref: #{new_target}"},
         follow_link?: false
       )
     else

--- a/lib/xgit/plumbing/update_index/cache_info.ex
+++ b/lib/xgit/plumbing/update_index/cache_info.ex
@@ -13,7 +13,7 @@ defmodule Xgit.Plumbing.UpdateIndex.CacheInfo do
   alias Xgit.Core.FilePath
   alias Xgit.Core.ObjectId
   alias Xgit.Plumbing.Util.WorkingTreeOpt
-  alias Xgit.Repository
+  alias Xgit.Repository.Storage
   alias Xgit.Repository.WorkingTree
 
   @typedoc ~S"""
@@ -35,7 +35,7 @@ defmodule Xgit.Plumbing.UpdateIndex.CacheInfo do
 
   ## Parameters
 
-  `repository` is the `Xgit.Repository` (PID) to which the new entries should be written.
+  `repository` is the `Xgit.Repository.Storage` (PID) to which the new entries should be written.
 
   `add`: a list of tuples of `{mode, object_id, path}` entries to add to the dir cache.
   In the event of collisions with existing entries, the existing entries will
@@ -49,7 +49,7 @@ defmodule Xgit.Plumbing.UpdateIndex.CacheInfo do
   `:ok` if successful.
 
   `{:error, :invalid_repository}` if `repository` doesn't represent a valid
-  `Xgit.Repository` process.
+  `Xgit.Repository.Storage` process.
 
   `{:error, :bare}` if `repository` doesn't have a working tree.
 
@@ -58,7 +58,7 @@ defmodule Xgit.Plumbing.UpdateIndex.CacheInfo do
   `{:error, :reason}` if unable. The relevant reason codes may come from
   `Xgit.Repository.WorkingTree.update_dir_cache/3`.
   """
-  @spec run(repository :: Repository.t(), add :: [add_entry], remove :: [FilePath.t()]) ::
+  @spec run(repository :: Storage.t(), add :: [add_entry], remove :: [FilePath.t()]) ::
           :ok | {:error, reason()}
   def run(repository, add, remove \\ [])
       when is_pid(repository) and is_list(add) and is_list(remove) do

--- a/lib/xgit/plumbing/update_ref.ex
+++ b/lib/xgit/plumbing/update_ref.ex
@@ -10,12 +10,12 @@ defmodule Xgit.Plumbing.UpdateRef do
 
   alias Xgit.Core.ObjectId
   alias Xgit.Core.Ref
-  alias Xgit.Repository
+  alias Xgit.Repository.Storage
 
   @typedoc ~S"""
   Reason codes that can be returned by `run/4`.
   """
-  @type reason :: :invalid_repository | Repository.put_ref_reason()
+  @type reason :: :invalid_repository | Storage.put_ref_reason()
 
   @doc ~S"""
   Translates the current working tree, as reflected in its index file, to one or more
@@ -25,7 +25,7 @@ defmodule Xgit.Plumbing.UpdateRef do
 
   ## Parameters
 
-  `repository` is the `Xgit.Repository` (PID) to search for the object.
+  `repository` is the `Xgit.Repository.Storage` (PID) to search for the object.
 
   `name` is the name of the reference to update. (See `t/Xgit.Core.Ref.name`.)
 
@@ -47,24 +47,24 @@ defmodule Xgit.Plumbing.UpdateRef do
   `:ok` if written successfully.
 
   `{:error, :invalid_repository}` if `repository` doesn't represent a valid
-  `Xgit.Repository` process.
+  `Xgit.Repository.Storage` process.
 
   Reason codes may also come from the following functions:
 
-  * `Xgit.Repository.put_ref/3`
-  * `Xgit.Repository.delete_ref/3`
+  * `Xgit.Repository.Storage.put_ref/3`
+  * `Xgit.Repository.Storage.delete_ref/3`
   """
-  @spec run(repository :: Repository.t(), name :: Ref.name(), new_value :: ObjectId.t(),
+  @spec run(repository :: Storage.t(), name :: Ref.name(), new_value :: ObjectId.t(),
           old_target: ObjectId.t()
         ) :: :ok | {:error, reason}
   def run(repository, name, new_value, opts \\ [])
       when is_pid(repository) and is_binary(name) and is_binary(new_value) and is_list(opts) do
-    with {:repository_valid?, true} <- {:repository_valid?, Repository.valid?(repository)},
+    with {:repository_valid?, true} <- {:repository_valid?, Storage.valid?(repository)},
          repo_opts <- validate_opts(opts) do
       if new_value == ObjectId.zero() do
-        Repository.delete_ref(repository, name, repo_opts)
+        Storage.delete_ref(repository, name, repo_opts)
       else
-        Repository.put_ref(repository, %Ref{name: name, target: new_value}, repo_opts)
+        Storage.put_ref(repository, %Ref{name: name, target: new_value}, repo_opts)
       end
     else
       {:repository_valid?, false} -> cover {:error, :invalid_repository}

--- a/lib/xgit/plumbing/util/working_tree_opt.ex
+++ b/lib/xgit/plumbing/util/working_tree_opt.ex
@@ -4,15 +4,15 @@ defmodule Xgit.Plumbing.Util.WorkingTreeOpt do
 
   import Xgit.Util.ForceCoverage
 
-  alias Xgit.Repository
+  alias Xgit.Repository.Storage
   alias Xgit.Repository.WorkingTree
 
   # Parse working tree and repository from arguments and options.
 
-  @spec get(repository :: Repository.t(), working_tree: WorkingTree.t()) ::
+  @spec get(repository :: Storage.t(), working_tree: WorkingTree.t()) ::
           {:ok, WorkingTree.t()} | {:error, :invalid_repository | :bare}
   def get(repository, opts \\ []) when is_pid(repository) and is_list(opts) do
-    with {:repository_valid?, true} <- {:repository_valid?, Repository.valid?(repository)},
+    with {:repository_valid?, true} <- {:repository_valid?, Storage.valid?(repository)},
          {:working_tree, working_tree} when is_pid(working_tree) <-
            {:working_tree, working_tree_from_repo_or_opts(repository, opts)} do
       cover {:ok, working_tree}
@@ -29,6 +29,6 @@ defmodule Xgit.Plumbing.Util.WorkingTreeOpt do
     # modules have that option documented when implemented.)
     # For now, only recognize default working tree.
 
-    Repository.default_working_tree(repository)
+    Storage.default_working_tree(repository)
   end
 end

--- a/lib/xgit/plumbing/write_tree.ex
+++ b/lib/xgit/plumbing/write_tree.ex
@@ -12,7 +12,7 @@ defmodule Xgit.Plumbing.WriteTree do
   alias Xgit.Core.FilePath
   alias Xgit.Core.ObjectId
   alias Xgit.Plumbing.Util.WorkingTreeOpt
-  alias Xgit.Repository
+  alias Xgit.Repository.Storage
   alias Xgit.Repository.WorkingTree
   alias Xgit.Repository.WorkingTree.ParseIndexFile
 
@@ -25,7 +25,7 @@ defmodule Xgit.Plumbing.WriteTree do
           | WorkingTree.write_tree_reason()
           | DirCache.to_tree_objects_reason()
           | ParseIndexFile.from_iodevice_reason()
-          | Repository.put_loose_object_reason()
+          | Storage.put_loose_object_reason()
 
   @doc ~S"""
   Translates the current working tree, as reflected in its index file, to one or more
@@ -35,7 +35,7 @@ defmodule Xgit.Plumbing.WriteTree do
 
   ## Parameters
 
-  `repository` is the `Xgit.Repository` (PID) to search for the object.
+  `repository` is the `Xgit.Repository.Storage` (PID) to search for the object.
 
   ## Options
 
@@ -52,18 +52,18 @@ defmodule Xgit.Plumbing.WriteTree do
   specified by the index already existed, it will return that existing tree's ID.)
 
   `{:error, :invalid_repository}` if `repository` doesn't represent a valid
-  `Xgit.Repository` process.
+  `Xgit.Repository.Storage` process.
 
   `{:error, :bare}` if `repository` doesn't have a working tree.
 
   Reason codes may also come from the following functions:
 
   * `Xgit.Core.DirCache.to_tree_objects/2`
-  * `Xgit.Repository.put_loose_object/2`
-  * `Xgit.Repository.WorkingTree.write_tree/2`
+  * `Xgit.Repository.Storage.put_loose_object/2`
+  * `Xgit.Repository.Storage.WorkingTree.write_tree/2`
   * `Xgit.Repository.WorkingTree.ParseIndexFile.from_iodevice/1`
   """
-  @spec run(repository :: Repository.t(), missing_ok?: boolean, prefix: FilePath.t()) ::
+  @spec run(repository :: Storage.t(), missing_ok?: boolean, prefix: FilePath.t()) ::
           {:ok, object_id :: ObjectId.t()}
           | {:error, reason :: reason}
   def run(repository, opts \\ []) when is_pid(repository) do

--- a/lib/xgit/repository/in_memory.ex
+++ b/lib/xgit/repository/in_memory.ex
@@ -1,12 +1,12 @@
 defmodule Xgit.Repository.InMemory do
   @moduledoc ~S"""
-  Implementation of `Xgit.Repository` that stores content in memory.
+  Implementation of `Xgit.Repository.Storage` that stores content in memory.
 
   _WARNING:_ This is intended for testing purposes only. As the name implies,
   repository content is stored only in memory. When the process that implements
   this repository terminates, the content it stores is lost.
   """
-  use Xgit.Repository
+  use Xgit.Repository.Storage
 
   import Xgit.Util.ForceCoverage
 
@@ -17,7 +17,8 @@ defmodule Xgit.Repository.InMemory do
   @doc ~S"""
   Start an in-memory git repository.
 
-  Use the functions in `Xgit.Repository` to interact with this repository process.
+  Use the functions in `Xgit.Repository.Storage` to interact with this
+  repository process.
 
   Any options are passed through to `GenServer.start_link/3`.
 
@@ -26,7 +27,7 @@ defmodule Xgit.Repository.InMemory do
   See `GenServer.start_link/3`.
   """
   @spec start_link(opts :: Keyword.t()) :: GenServer.on_start()
-  def start_link(opts \\ []), do: Repository.start_link(__MODULE__, opts, opts)
+  def start_link(opts \\ []), do: Storage.start_link(__MODULE__, opts, opts)
 
   @impl true
   def init(opts) when is_list(opts) do

--- a/lib/xgit/repository/on_disk.ex
+++ b/lib/xgit/repository/on_disk.ex
@@ -1,6 +1,7 @@
 defmodule Xgit.Repository.OnDisk do
   @moduledoc ~S"""
-  Implementation of `Xgit.Repository` that stores content on the local file system.
+  Implementation of `Xgit.Repository.Storage` that stores content on the
+  local file system.
 
   _IMPORTANT NOTE:_ This is intended as a reference implementation largely
   for testing purposes and may not necessarily handle all of the edge cases that
@@ -9,7 +10,7 @@ defmodule Xgit.Repository.OnDisk do
   That said, it does intentionally use the same `.git` folder format as command-line
   `git` so that results may be compared for similar operations.
   """
-  use Xgit.Repository
+  use Xgit.Repository.Storage
 
   import Xgit.Util.ForceCoverage
 
@@ -24,7 +25,7 @@ defmodule Xgit.Repository.OnDisk do
   @doc ~S"""
   Start an on-disk git repository.
 
-  Use the functions in `Xgit.Repository` to interact with this repository process.
+  Use the functions in `Xgit.Repository.Storage` to interact with this repository process.
 
   An `Xgit.Repository.WorkingTree` will be automatically created and attached
   to this repository.
@@ -46,9 +47,9 @@ defmodule Xgit.Repository.OnDisk do
   @spec start_link(work_dir: Path.t()) :: GenServer.on_start()
   def start_link(opts) do
     with {:ok, work_dir} <- get_work_dir_opt(opts),
-         {:ok, repo} <- Repository.start_link(__MODULE__, work_dir, opts),
+         {:ok, repo} <- Storage.start_link(__MODULE__, work_dir, opts),
          {:ok, working_tree} <- WorkingTree.start_link(repo, work_dir),
-         :ok <- Repository.set_default_working_tree(repo, working_tree) do
+         :ok <- Storage.set_default_working_tree(repo, working_tree) do
       cover {:ok, repo}
     else
       err -> err

--- a/lib/xgit/repository/storage.ex
+++ b/lib/xgit/repository/storage.ex
@@ -1,30 +1,23 @@
-defmodule Xgit.Repository do
+defmodule Xgit.Repository.Storage do
   @moduledoc ~S"""
-  Represents an abstract git repository.
+  Represents the persistent storage for a git repository.
 
-  ## Looking for Typical Git Commands?
-
-  The operations to inspect or mutate a git repository are not located in this
-  module. (See _Design Goals,_ below, and
-  [the `README.md` file in the `lib/xgit` folder](https://github.com/elixir-git/xgit/tree/master/lib/xgit/)
-  for an explanation.)
-
-  You'll find these operations in the modules named `Xgit.Api.*` _(none yet as
-  of this writing)_ and `Xgit.Plumbing.*`
+  Unless you are implementing an alternative storage architecture or implementing
+  plumbing-level commands, this module is probably not of interest to you.
 
   ## Design Goals
 
   Xgit intends to allow repositories to be stored in multiple different mechanisms.
   While it includes built-in support for local on-disk repositories
-  (see `Xgit.Repository.OnDisk`), and in-lib repositories (see `Xgit.Repository.InMemory`),
+  (see `Xgit.Repository.OnDisk`), and in-member repositories (see `Xgit.Repository.InMemory`),
   you could envision repositories stored entirely on a remote file system or database.
 
   ## Implementing a Storage Architecture
 
-  To define a new mechanism for storing a git repo, start by creating a new module
-  that `use`s this module and implements the required callbacks. Consider the
-  information stored in a typical `.git` directory in a local repository. You will
-  be building an alternative to that storage mechanism.
+  To define a new mechanism for storing a git repo, create a new module that `use`s
+  this module and implements the required callbacks. Consider the information stored
+  in a typical `.git` directory in a local repository. You will be building an
+  alternative to that storage mechanism.
   """
   use GenServer
 
@@ -38,12 +31,12 @@ defmodule Xgit.Repository do
   require Logger
 
   @typedoc ~S"""
-  The process ID for a `Repository` process.
+  The process ID for an `Xgit.Repository.Storage` process.
   """
   @type t :: pid
 
   @doc """
-  Starts a `Repository` process linked to the current process.
+  Starts an `Xgit.Repository.Storage` process linked to the current process.
 
   _IMPORTANT:_ You should not invoke this function directly unless you are
   implementing a new storage implementation module that implements this behaviour.
@@ -74,7 +67,7 @@ defmodule Xgit.Repository do
   end
 
   @doc ~S"""
-  Returns `true` if the argument is a PID representing a valid `Repository` process.
+  Returns `true` if the argument is a PID representing a valid `Xgit.Repository.Storage` process.
   """
   @spec valid?(repository :: term) :: boolean
   def valid?(repository) when is_pid(repository) do
@@ -534,8 +527,8 @@ defmodule Xgit.Repository do
   defmacro __using__(opts) do
     quote location: :keep, bind_quoted: [opts: opts] do
       use GenServer, opts
-      alias Xgit.Repository
-      @behaviour Repository
+      alias Xgit.Repository.Storage
+      @behaviour Storage
     end
   end
 end

--- a/test/support/test/on_disk_repo_test_case.ex
+++ b/test/support/test/on_disk_repo_test_case.ex
@@ -20,7 +20,7 @@ defmodule Xgit.Test.OnDiskRepoTestCase do
   @spec repo!(path :: Path.t() | nil) :: %{
           tmp_dir: Path.t(),
           xgit_path: Path.t(),
-          xgit_repo: Repository.t()
+          xgit_repo: Storage.t()
         }
   def repo!(path \\ nil)
 
@@ -66,7 +66,7 @@ defmodule Xgit.Test.OnDiskRepoTestCase do
   @spec setup_with_valid_tree!(path :: Path.t() | nil) :: %{
           tmp_dir: Path.t(),
           xgit_path: Path.t(),
-          xgit_repo: Repository.t(),
+          xgit_repo: Storage.t(),
           tree_id: binary()
         }
   def setup_with_valid_tree!(path \\ nil) do
@@ -130,7 +130,7 @@ defmodule Xgit.Test.OnDiskRepoTestCase do
   @spec setup_with_valid_parent_commit!(path :: Path.t() | nil) :: %{
           tmp_dir: Path.t(),
           xgit_path: Path.t(),
-          xgit_repo: Repository.t(),
+          xgit_repo: Storage.t(),
           tree_id: String.t(),
           parent_id: String.t()
         }

--- a/test/xgit/core/commit_test.exs
+++ b/test/xgit/core/commit_test.exs
@@ -5,8 +5,8 @@ defmodule Xgit.Core.CommitTest do
   alias Xgit.Core.Object
   alias Xgit.Core.PersonIdent
   alias Xgit.GitInitTestCase
-  alias Xgit.Repository
   alias Xgit.Repository.OnDisk
+  alias Xgit.Repository.Storage
   alias Xgit.Test.OnDiskRepoTestCase
 
   import FolderDiff
@@ -228,7 +228,7 @@ defmodule Xgit.Core.CommitTest do
 
       commit_id = String.trim(commit_id_str)
 
-      {:ok, commit_object} = Repository.get_object(repo, commit_id)
+      {:ok, commit_object} = Storage.get_object(repo, commit_id)
 
       assert {:ok,
               %Xgit.Core.Commit{
@@ -262,7 +262,7 @@ defmodule Xgit.Core.CommitTest do
 
       commit_id = String.trim(commit_id_str)
 
-      {:ok, commit_object} = Repository.get_object(repo, commit_id)
+      {:ok, commit_object} = Storage.get_object(repo, commit_id)
 
       assert {:ok,
               %Xgit.Core.Commit{
@@ -1081,7 +1081,7 @@ defmodule Xgit.Core.CommitTest do
       {output, 0} = System.cmd("git", ["write-tree", "--missing-ok"], cd: xgit)
       assert tree_content_id == String.trim(output)
 
-      :ok = Repository.put_loose_object(repo, xgit_commit_object)
+      :ok = Storage.put_loose_object(repo, xgit_commit_object)
 
       assert_folders_are_equal(
         Path.join([ref, ".git", "objects"]),

--- a/test/xgit/core/dir_cache_test.exs
+++ b/test/xgit/core/dir_cache_test.exs
@@ -4,8 +4,8 @@ defmodule Xgit.Core.DirCacheTest do
   alias Xgit.Core.DirCache
   alias Xgit.Core.DirCache.Entry
   alias Xgit.GitInitTestCase
-  alias Xgit.Repository
   alias Xgit.Repository.OnDisk
+  alias Xgit.Repository.Storage
 
   import FolderDiff
 
@@ -660,7 +660,7 @@ defmodule Xgit.Core.DirCacheTest do
       {:ok, repo} = OnDisk.start_link(work_dir: xgit)
 
       Enum.each(tree_objects, fn tree_object ->
-        :ok = Repository.put_loose_object(repo, tree_object)
+        :ok = Storage.put_loose_object(repo, tree_object)
       end)
 
       assert_folders_are_equal(

--- a/test/xgit/core/tree_test.exs
+++ b/test/xgit/core/tree_test.exs
@@ -5,8 +5,8 @@ defmodule Xgit.Core.TreeTest do
   alias Xgit.Core.Tree
   alias Xgit.Core.Tree.Entry
   alias Xgit.GitInitTestCase
-  alias Xgit.Repository
   alias Xgit.Repository.OnDisk
+  alias Xgit.Repository.Storage
   alias Xgit.Test.OnDiskRepoTestCase
 
   import FolderDiff
@@ -78,7 +78,7 @@ defmodule Xgit.Core.TreeTest do
       {output, 0} = System.cmd("git", ["write-tree", "--missing-ok"], cd: xgit_path)
       tree_id = String.trim(output)
 
-      assert {:ok, %Object{} = object} = Repository.get_object(xgit_repo, tree_id)
+      assert {:ok, %Object{} = object} = Storage.get_object(xgit_repo, tree_id)
       assert {:ok, %Tree{entries: entries} = _tree} = Tree.from_object(object)
 
       entries
@@ -297,7 +297,7 @@ defmodule Xgit.Core.TreeTest do
       :ok = OnDisk.create(xgit)
       {:ok, repo} = OnDisk.start_link(work_dir: xgit)
 
-      :ok = Repository.put_loose_object(repo, tree_object)
+      :ok = Storage.put_loose_object(repo, tree_object)
 
       assert_folders_are_equal(
         Path.join([ref, ".git", "objects"]),

--- a/test/xgit/plumbing/commit_tree_test.exs
+++ b/test/xgit/plumbing/commit_tree_test.exs
@@ -4,7 +4,7 @@ defmodule Xgit.Plumbing.CommitTreeTest do
   alias Xgit.Core.Object
   alias Xgit.Core.PersonIdent
   alias Xgit.Plumbing.CommitTree
-  alias Xgit.Repository
+  alias Xgit.Repository.Storage
   alias Xgit.Test.OnDiskRepoTestCase
 
   import FolderDiff
@@ -205,7 +205,7 @@ defmodule Xgit.Plumbing.CommitTreeTest do
         id: "d670460b4b4aece5915caf5c68d12f560a9fe3e4"
       }
 
-      :ok = Repository.put_loose_object(xgit_repo, object)
+      :ok = Storage.put_loose_object(xgit_repo, object)
 
       assert {:error, :invalid_tree} =
                CommitTree.run(xgit_repo,

--- a/test/xgit/plumbing/ls_files/stage_test.exs
+++ b/test/xgit/plumbing/ls_files/stage_test.exs
@@ -3,9 +3,9 @@ defmodule Xgit.Plumbing.LsFiles.StageTest do
 
   alias Xgit.Core.DirCache.Entry, as: DirCacheEntry
   alias Xgit.Plumbing.LsFiles.Stage, as: LsFilesStage
-  alias Xgit.Repository
   alias Xgit.Repository.InMemory
   alias Xgit.Repository.OnDisk
+  alias Xgit.Repository.Storage
   alias Xgit.Repository.WorkingTree
   alias Xgit.Test.TempDirTestCase
 
@@ -16,7 +16,7 @@ defmodule Xgit.Plumbing.LsFiles.StageTest do
       %{tmp_dir: path} = TempDirTestCase.tmp_dir!()
 
       {:ok, working_tree} = WorkingTree.start_link(repo, path)
-      :ok = Repository.set_default_working_tree(repo, working_tree)
+      :ok = Storage.set_default_working_tree(repo, working_tree)
 
       assert {:ok, []} = LsFilesStage.run(repo)
     end

--- a/test/xgit/plumbing/read_tree_test.exs
+++ b/test/xgit/plumbing/read_tree_test.exs
@@ -6,9 +6,9 @@ defmodule Xgit.Plumbing.ReadTreeTest do
   alias Xgit.GitInitTestCase
   alias Xgit.Plumbing.ReadTree
   alias Xgit.Plumbing.UpdateIndex.CacheInfo
-  alias Xgit.Repository
   alias Xgit.Repository.InMemory
   alias Xgit.Repository.OnDisk
+  alias Xgit.Repository.Storage
   alias Xgit.Repository.WorkingTree
   alias Xgit.Test.OnDiskRepoTestCase
 
@@ -113,7 +113,7 @@ defmodule Xgit.Plumbing.ReadTreeTest do
 
       assert :ok = ReadTree.run(repo, :empty)
 
-      working_tree = Repository.default_working_tree(repo)
+      working_tree = Storage.default_working_tree(repo)
       assert {:ok, dir_cache} = WorkingTree.dir_cache(working_tree)
     end
 
@@ -490,7 +490,7 @@ defmodule Xgit.Plumbing.ReadTreeTest do
 
       assert :ok = ReadTree.run(repo, tree_object_id, opts)
 
-      working_tree = Repository.default_working_tree(repo)
+      working_tree = Storage.default_working_tree(repo)
       assert {:ok, dir_cache} = WorkingTree.dir_cache(working_tree)
 
       dir_cache

--- a/test/xgit/plumbing/symbolic_ref/put_test.exs
+++ b/test/xgit/plumbing/symbolic_ref/put_test.exs
@@ -5,7 +5,7 @@ defmodule Xgit.Plumbing.SymbolicRef.PutTest do
   alias Xgit.Plumbing.HashObject
   alias Xgit.Plumbing.SymbolicRef.Put
   alias Xgit.Plumbing.UpdateRef
-  alias Xgit.Repository
+  alias Xgit.Repository.Storage
   alias Xgit.Test.OnDiskRepoTestCase
 
   import FolderDiff
@@ -59,9 +59,9 @@ defmodule Xgit.Plumbing.SymbolicRef.PutTest do
 
       assert :ok = UpdateRef.run(repo, "HEAD", commit_id_master)
 
-      assert {:ok, [^master_ref]} = Repository.list_refs(repo)
-      assert {:ok, ^master_ref} = Repository.get_ref(repo, "refs/heads/master")
-      assert {:ok, ^master_ref_via_head} = Repository.get_ref(repo, "HEAD")
+      assert {:ok, [^master_ref]} = Storage.list_refs(repo)
+      assert {:ok, ^master_ref} = Storage.get_ref(repo, "refs/heads/master")
+      assert {:ok, ^master_ref_via_head} = Storage.get_ref(repo, "HEAD")
 
       {:ok, commit_id_other} =
         HashObject.run('shhh... another not commit',
@@ -86,9 +86,9 @@ defmodule Xgit.Plumbing.SymbolicRef.PutTest do
 
       assert :ok = UpdateRef.run(repo, "HEAD", commit_id_other)
 
-      assert {:ok, [^master_ref, ^other_ref]} = Repository.list_refs(repo)
-      assert {:ok, ^master_ref} = Repository.get_ref(repo, "refs/heads/master")
-      assert {:ok, ^other_ref_via_head} = Repository.get_ref(repo, "HEAD")
+      assert {:ok, [^master_ref, ^other_ref]} = Storage.list_refs(repo)
+      assert {:ok, ^master_ref} = Storage.get_ref(repo, "refs/heads/master")
+      assert {:ok, ^other_ref_via_head} = Storage.get_ref(repo, "HEAD")
     end
 
     test "result can be read by command-line git" do

--- a/test/xgit/plumbing/update_ref_test.exs
+++ b/test/xgit/plumbing/update_ref_test.exs
@@ -6,7 +6,7 @@ defmodule Xgit.Plumbing.UpdateRefTest do
   alias Xgit.Core.Ref
   alias Xgit.Plumbing.HashObject
   alias Xgit.Plumbing.UpdateRef
-  alias Xgit.Repository
+  alias Xgit.Repository.Storage
   alias Xgit.Test.OnDiskRepoTestCase
 
   import FolderDiff
@@ -32,7 +32,7 @@ defmodule Xgit.Plumbing.UpdateRefTest do
       %{xgit_repo: repo} = OnDiskRepoTestCase.repo!()
 
       object = %Object{type: :blob, content: @test_content, size: 13, id: @test_content_id}
-      :ok = Repository.put_loose_object(repo, object)
+      :ok = Storage.put_loose_object(repo, object)
 
       assert {:error, :target_not_commit} =
                UpdateRef.run(repo, "refs/heads/master", @test_content_id)
@@ -88,7 +88,7 @@ defmodule Xgit.Plumbing.UpdateRefTest do
 
       assert :ok = UpdateRef.run(repo, "refs/heads/master", commit_id_master)
 
-      assert {:ok, [^master_ref]} = Repository.list_refs(repo)
+      assert {:ok, [^master_ref]} = Storage.list_refs(repo)
 
       {:ok, commit_id_other} =
         HashObject.run('shhh... another fake commit',
@@ -105,10 +105,10 @@ defmodule Xgit.Plumbing.UpdateRefTest do
 
       assert :ok = UpdateRef.run(repo, "refs/heads/other", commit_id_other)
 
-      assert {:ok, ^master_ref} = Repository.get_ref(repo, "refs/heads/master")
-      assert {:ok, ^other_ref} = Repository.get_ref(repo, "refs/heads/other")
+      assert {:ok, ^master_ref} = Storage.get_ref(repo, "refs/heads/master")
+      assert {:ok, ^other_ref} = Storage.get_ref(repo, "refs/heads/other")
 
-      assert {:ok, [^master_ref, ^other_ref]} = Repository.list_refs(repo)
+      assert {:ok, [^master_ref, ^other_ref]} = Storage.list_refs(repo)
     end
 
     test "follows HEAD reference" do
@@ -135,9 +135,9 @@ defmodule Xgit.Plumbing.UpdateRefTest do
 
       assert :ok = UpdateRef.run(repo, "HEAD", commit_id_master)
 
-      assert {:ok, [^master_ref]} = Repository.list_refs(repo)
-      assert {:ok, ^master_ref} = Repository.get_ref(repo, "refs/heads/master")
-      assert {:ok, ^master_ref_via_head} = Repository.get_ref(repo, "HEAD")
+      assert {:ok, [^master_ref]} = Storage.list_refs(repo)
+      assert {:ok, ^master_ref} = Storage.get_ref(repo, "refs/heads/master")
+      assert {:ok, ^master_ref_via_head} = Storage.get_ref(repo, "HEAD")
     end
 
     test "result can be read by command-line git" do
@@ -205,7 +205,7 @@ defmodule Xgit.Plumbing.UpdateRefTest do
       }
 
       assert :ok = UpdateRef.run(repo, "refs/heads/master", commit_id_master)
-      assert {:ok, [^master_ref]} = Repository.list_refs(repo)
+      assert {:ok, [^master_ref]} = Storage.list_refs(repo)
 
       {:ok, commit_id2_master} =
         HashObject.run('shhh... another not commit',
@@ -225,7 +225,7 @@ defmodule Xgit.Plumbing.UpdateRefTest do
                  old_target: commit_id_master
                )
 
-      assert {:ok, [^master_ref2]} = Repository.list_refs(repo)
+      assert {:ok, [^master_ref2]} = Storage.list_refs(repo)
     end
 
     test ":old_target (incorrect match)" do
@@ -245,7 +245,7 @@ defmodule Xgit.Plumbing.UpdateRefTest do
       }
 
       assert :ok = UpdateRef.run(repo, "refs/heads/master", commit_id_master)
-      assert {:ok, [^master_ref]} = Repository.list_refs(repo)
+      assert {:ok, [^master_ref]} = Storage.list_refs(repo)
 
       {:ok, commit_id2_master} =
         HashObject.run('shhh... another not commit',
@@ -260,7 +260,7 @@ defmodule Xgit.Plumbing.UpdateRefTest do
                  old_target: "2075df9dff2b5a10ad417586b4edde66af849bad"
                )
 
-      assert {:ok, [^master_ref]} = Repository.list_refs(repo)
+      assert {:ok, [^master_ref]} = Storage.list_refs(repo)
     end
 
     test ":old_target (does not exist)" do
@@ -280,7 +280,7 @@ defmodule Xgit.Plumbing.UpdateRefTest do
       }
 
       assert :ok = UpdateRef.run(repo, "refs/heads/master", commit_id_master)
-      assert {:ok, [^master_ref]} = Repository.list_refs(repo)
+      assert {:ok, [^master_ref]} = Storage.list_refs(repo)
 
       {:ok, commit_id2_master} =
         HashObject.run('shhh... another not commit',
@@ -295,7 +295,7 @@ defmodule Xgit.Plumbing.UpdateRefTest do
                  old_target: commit_id_master
                )
 
-      assert {:ok, [^master_ref]} = Repository.list_refs(repo)
+      assert {:ok, [^master_ref]} = Storage.list_refs(repo)
     end
 
     test ":old_target = :new" do
@@ -315,7 +315,7 @@ defmodule Xgit.Plumbing.UpdateRefTest do
       }
 
       assert :ok = UpdateRef.run(repo, "refs/heads/master", commit_id_master, old_target: :new)
-      assert {:ok, [^master_ref]} = Repository.list_refs(repo)
+      assert {:ok, [^master_ref]} = Storage.list_refs(repo)
     end
 
     test ":old_target = :new, but target does exist" do
@@ -335,7 +335,7 @@ defmodule Xgit.Plumbing.UpdateRefTest do
       }
 
       assert :ok = UpdateRef.run(repo, "refs/heads/master", commit_id_master)
-      assert {:ok, [^master_ref]} = Repository.list_refs(repo)
+      assert {:ok, [^master_ref]} = Storage.list_refs(repo)
 
       {:ok, commit_id2_master} =
         HashObject.run('shhh... another not commit',
@@ -348,7 +348,7 @@ defmodule Xgit.Plumbing.UpdateRefTest do
       assert {:error, :old_target_not_matched} =
                UpdateRef.run(repo, "refs/heads/master", commit_id2_master, old_target: :new)
 
-      assert {:ok, [^master_ref]} = Repository.list_refs(repo)
+      assert {:ok, [^master_ref]} = Storage.list_refs(repo)
     end
 
     test "target 0000 removes an existing ref" do
@@ -369,34 +369,34 @@ defmodule Xgit.Plumbing.UpdateRefTest do
 
       assert :ok = UpdateRef.run(repo, "refs/heads/master", commit_id_master)
 
-      assert {:ok, [^master_ref]} = Repository.list_refs(repo)
+      assert {:ok, [^master_ref]} = Storage.list_refs(repo)
 
       assert :ok = UpdateRef.run(repo, "refs/heads/master", ObjectId.zero())
 
-      assert {:error, :not_found} = Repository.get_ref(repo, "refs/heads/master")
-      assert {:ok, []} = Repository.list_refs(repo)
+      assert {:error, :not_found} = Storage.get_ref(repo, "refs/heads/master")
+      assert {:ok, []} = Storage.list_refs(repo)
     end
 
     test "target 0000 quietly 'succeeds' if ref didn't exist" do
       %{xgit_repo: repo} = OnDiskRepoTestCase.repo!()
 
-      assert {:ok, []} = Repository.list_refs(repo)
+      assert {:ok, []} = Storage.list_refs(repo)
 
       assert :ok = UpdateRef.run(repo, "refs/heads/master", ObjectId.zero())
 
-      assert {:error, :not_found} = Repository.get_ref(repo, "refs/heads/master")
-      assert {:ok, []} = Repository.list_refs(repo)
+      assert {:error, :not_found} = Storage.get_ref(repo, "refs/heads/master")
+      assert {:ok, []} = Storage.list_refs(repo)
     end
 
     test "target 0000 error if name invalid" do
       %{xgit_repo: repo} = OnDiskRepoTestCase.repo!()
 
-      assert {:ok, []} = Repository.list_refs(repo)
+      assert {:ok, []} = Storage.list_refs(repo)
 
       assert {:error, :invalid_ref} = UpdateRef.run(repo, "refs", ObjectId.zero())
 
-      assert {:error, :not_found} = Repository.get_ref(repo, "refs/heads/master")
-      assert {:ok, []} = Repository.list_refs(repo)
+      assert {:error, :not_found} = Storage.get_ref(repo, "refs/heads/master")
+      assert {:ok, []} = Storage.list_refs(repo)
     end
 
     test "delete :old_target matches existing ref" do
@@ -417,15 +417,15 @@ defmodule Xgit.Plumbing.UpdateRefTest do
 
       assert :ok = UpdateRef.run(repo, "refs/heads/master", commit_id_master)
 
-      assert {:ok, [^master_ref]} = Repository.list_refs(repo)
+      assert {:ok, [^master_ref]} = Storage.list_refs(repo)
 
       assert :ok =
                UpdateRef.run(repo, "refs/heads/master", ObjectId.zero(),
                  old_target: commit_id_master
                )
 
-      assert {:error, :not_found} = Repository.get_ref(repo, "refs/heads/master")
-      assert {:ok, []} = Repository.list_refs(repo)
+      assert {:error, :not_found} = Storage.get_ref(repo, "refs/heads/master")
+      assert {:ok, []} = Storage.list_refs(repo)
     end
 
     test "delete doesn't remove ref if :old_target doesn't match" do
@@ -446,29 +446,29 @@ defmodule Xgit.Plumbing.UpdateRefTest do
 
       assert :ok = UpdateRef.run(repo, "refs/heads/master", commit_id_master)
 
-      assert {:ok, [^master_ref]} = Repository.list_refs(repo)
+      assert {:ok, [^master_ref]} = Storage.list_refs(repo)
 
       assert {:error, :old_target_not_matched} =
                UpdateRef.run(repo, "refs/heads/master", ObjectId.zero(),
                  old_target: "bec43c416143e6b8bf9a3b559260185757e1386b"
                )
 
-      assert {:ok, ^master_ref} = Repository.get_ref(repo, "refs/heads/master")
-      assert {:ok, [^master_ref]} = Repository.list_refs(repo)
+      assert {:ok, ^master_ref} = Storage.get_ref(repo, "refs/heads/master")
+      assert {:ok, [^master_ref]} = Storage.list_refs(repo)
     end
 
     test "delete error if :old_target specified and no ref exists" do
       %{xgit_repo: repo} = OnDiskRepoTestCase.repo!()
 
-      assert {:ok, []} = Repository.list_refs(repo)
+      assert {:ok, []} = Storage.list_refs(repo)
 
       assert {:error, :old_target_not_matched} =
                UpdateRef.run(repo, "refs/heads/master", ObjectId.zero(),
                  old_target: "bec43c416143e6b8bf9a3b559260185757e1386b"
                )
 
-      assert {:error, :not_found} = Repository.get_ref(repo, "refs/heads/master")
-      assert {:ok, []} = Repository.list_refs(repo)
+      assert {:error, :not_found} = Storage.get_ref(repo, "refs/heads/master")
+      assert {:ok, []} = Storage.list_refs(repo)
     end
 
     test "delete {:error, :cant_delete_file}" do

--- a/test/xgit/plumbing/write_tree_test.exs
+++ b/test/xgit/plumbing/write_tree_test.exs
@@ -6,8 +6,8 @@ defmodule Xgit.Plumbing.WriteTreeTest do
   alias Xgit.Plumbing.HashObject
   alias Xgit.Plumbing.UpdateIndex.CacheInfo
   alias Xgit.Plumbing.WriteTree
-  alias Xgit.Repository
   alias Xgit.Repository.OnDisk
+  alias Xgit.Repository.Storage
   alias Xgit.Repository.WorkingTree
 
   import FolderDiff
@@ -445,7 +445,7 @@ defmodule Xgit.Plumbing.WriteTreeTest do
       :ok = OnDisk.create(xgit)
       {:ok, repo} = OnDisk.start_link(work_dir: xgit)
 
-      working_tree = Repository.default_working_tree(repo)
+      working_tree = Storage.default_working_tree(repo)
 
       :ok =
         WorkingTree.update_dir_cache(
@@ -463,7 +463,7 @@ defmodule Xgit.Plumbing.WriteTreeTest do
       :ok = OnDisk.create(xgit)
       {:ok, repo} = OnDisk.start_link(work_dir: xgit)
 
-      working_tree = Repository.default_working_tree(repo)
+      working_tree = Storage.default_working_tree(repo)
       :ok = WorkingTree.update_dir_cache(working_tree, [@valid_entry], [])
 
       objects_path = Path.join([xgit, ".git", "objects"])

--- a/test/xgit/repository/default_working_tree_test.exs
+++ b/test/xgit/repository/default_working_tree_test.exs
@@ -1,8 +1,8 @@
 defmodule Xgit.Repository.DefaultWorkingTreeTest do
   use ExUnit.Case, async: true
 
-  alias Xgit.Repository
   alias Xgit.Repository.InMemory
+  alias Xgit.Repository.Storage
   alias Xgit.Repository.WorkingTree
   alias Xgit.Test.TempDirTestCase
 
@@ -13,7 +13,7 @@ defmodule Xgit.Repository.DefaultWorkingTreeTest do
     test "happy path" do
       {:ok, repo} = InMemory.start_link()
 
-      assert Repository.default_working_tree(repo) == nil
+      assert Storage.default_working_tree(repo) == nil
 
       # Create a working tree and assign it.
 
@@ -21,14 +21,14 @@ defmodule Xgit.Repository.DefaultWorkingTreeTest do
 
       {:ok, working_tree} = WorkingTree.start_link(repo, path)
 
-      assert :ok = Repository.set_default_working_tree(repo, working_tree)
-      assert Repository.default_working_tree(repo) == working_tree
+      assert :ok = Storage.set_default_working_tree(repo, working_tree)
+      assert Storage.default_working_tree(repo) == working_tree
 
       # Kids, don't try this at home.
 
       {:ok, working_tree2} = WorkingTree.start_link(repo, path)
-      assert :error = Repository.set_default_working_tree(repo, working_tree2)
-      assert Repository.default_working_tree(repo) == working_tree
+      assert :error = Storage.set_default_working_tree(repo, working_tree2)
+      assert Storage.default_working_tree(repo) == working_tree
 
       # Ensure working tree dies with repo.
 
@@ -43,7 +43,7 @@ defmodule Xgit.Repository.DefaultWorkingTreeTest do
       {:ok, repo} = InMemory.start_link()
       {:ok, not_working_tree} = GenServer.start_link(NotValid, nil)
 
-      assert :error = Repository.set_default_working_tree(repo, not_working_tree)
+      assert :error = Storage.set_default_working_tree(repo, not_working_tree)
     end
   end
 end

--- a/test/xgit/repository/in_memory/get_object_test.exs
+++ b/test/xgit/repository/in_memory/get_object_test.exs
@@ -1,8 +1,8 @@
 defmodule Xgit.Repository.InMemory.GetObjectTest do
   use Xgit.GitInitTestCase, async: true
 
-  alias Xgit.Repository
   alias Xgit.Repository.InMemory
+  alias Xgit.Repository.Storage
 
   describe "get_object/2" do
     # Happy paths involving existing items are tested in put_loose_object_test.
@@ -11,7 +11,7 @@ defmodule Xgit.Repository.InMemory.GetObjectTest do
       assert {:ok, repo} = InMemory.start_link()
 
       assert {:error, :not_found} =
-               Repository.get_object(repo, "5cb5d77be2d92c7368038dac67e648a69e0a654d")
+               Storage.get_object(repo, "5cb5d77be2d92c7368038dac67e648a69e0a654d")
     end
   end
 end

--- a/test/xgit/repository/in_memory/has_all_object_ids_test.exs
+++ b/test/xgit/repository/in_memory/has_all_object_ids_test.exs
@@ -2,8 +2,8 @@ defmodule Xgit.Repository.InMemory.HasAllObjectIdsTest do
   use ExUnit.Case, async: true
 
   alias Xgit.Core.Object
-  alias Xgit.Repository
   alias Xgit.Repository.InMemory
+  alias Xgit.Repository.Storage
 
   describe "has_all_object_ids?/2" do
     @test_content 'test content\n'
@@ -13,7 +13,7 @@ defmodule Xgit.Repository.InMemory.HasAllObjectIdsTest do
       assert {:ok, repo} = InMemory.start_link()
 
       object = %Object{type: :blob, content: @test_content, size: 13, id: @test_content_id}
-      assert :ok = Repository.put_loose_object(repo, object)
+      assert :ok = Storage.put_loose_object(repo, object)
 
       # Yes, the hash is wrong, but we'll ignore that for now.
       object = %Object{
@@ -23,35 +23,35 @@ defmodule Xgit.Repository.InMemory.HasAllObjectIdsTest do
         id: "c1e116090ad56f172370351ab3f773eb0f1fe89e"
       }
 
-      assert :ok = Repository.put_loose_object(repo, object)
+      assert :ok = Storage.put_loose_object(repo, object)
 
       {:ok, repo: repo}
     end
 
     test "happy path: zero object IDs", %{repo: repo} do
-      assert Repository.has_all_object_ids?(repo, [])
+      assert Storage.has_all_object_ids?(repo, [])
     end
 
     test "happy path: one object ID", %{repo: repo} do
-      assert Repository.has_all_object_ids?(repo, [@test_content_id])
+      assert Storage.has_all_object_ids?(repo, [@test_content_id])
     end
 
     test "happy path: two object IDs", %{repo: repo} do
-      assert Repository.has_all_object_ids?(repo, [
+      assert Storage.has_all_object_ids?(repo, [
                @test_content_id,
                "c1e116090ad56f172370351ab3f773eb0f1fe89e"
              ])
     end
 
     test "happy path: partial match", %{repo: repo} do
-      refute Repository.has_all_object_ids?(repo, [
+      refute Storage.has_all_object_ids?(repo, [
                @test_content_id,
                "b9e3a9e3ea7dde01d652f899a783b75a1518564c"
              ])
     end
 
     test "happy path: no match", %{repo: repo} do
-      refute Repository.has_all_object_ids?(repo, [
+      refute Storage.has_all_object_ids?(repo, [
                @test_content_id,
                "6ee878a55ed36e2cda2c68452d2336ce3bd692d1"
              ])

--- a/test/xgit/repository/in_memory/put_loose_object_test.exs
+++ b/test/xgit/repository/in_memory/put_loose_object_test.exs
@@ -4,8 +4,8 @@ defmodule Xgit.Repository.InMemory.PutLooseObjectTest do
   alias Xgit.Core.ContentSource
   alias Xgit.Core.FileContentSource
   alias Xgit.Core.Object
-  alias Xgit.Repository
   alias Xgit.Repository.InMemory
+  alias Xgit.Repository.Storage
 
   describe "put_loose_object/2" do
     # Also tests corresonding cases of get_object/2.
@@ -16,9 +16,9 @@ defmodule Xgit.Repository.InMemory.PutLooseObjectTest do
       assert {:ok, repo} = InMemory.start_link()
 
       object = %Object{type: :blob, content: @test_content, size: 13, id: @test_content_id}
-      assert :ok = Repository.put_loose_object(repo, object)
+      assert :ok = Storage.put_loose_object(repo, object)
 
-      assert {:ok, ^object} = Repository.get_object(repo, @test_content_id)
+      assert {:ok, ^object} = Storage.get_object(repo, @test_content_id)
     end
 
     test "happy path: reads file into memory" do
@@ -38,7 +38,7 @@ defmodule Xgit.Repository.InMemory.PutLooseObjectTest do
 
       fcs = FileContentSource.new(path)
       object = %Object{type: :blob, content: fcs, size: ContentSource.length(fcs), id: content_id}
-      assert :ok = Repository.put_loose_object(repo, object)
+      assert :ok = Storage.put_loose_object(repo, object)
 
       content_as_binary = :binary.bin_to_list(content)
       content_size = byte_size(content)
@@ -49,7 +49,7 @@ defmodule Xgit.Repository.InMemory.PutLooseObjectTest do
                 content: ^content_as_binary,
                 size: ^content_size,
                 id: ^content_id
-              }} = Repository.get_object(repo, content_id)
+              }} = Storage.get_object(repo, content_id)
 
       assert Object.valid?(object)
     end
@@ -58,11 +58,11 @@ defmodule Xgit.Repository.InMemory.PutLooseObjectTest do
       assert {:ok, repo} = InMemory.start_link()
 
       object = %Object{type: :blob, content: @test_content, size: 13, id: @test_content_id}
-      assert :ok = Repository.put_loose_object(repo, object)
+      assert :ok = Storage.put_loose_object(repo, object)
 
-      assert {:error, :object_exists} = Repository.put_loose_object(repo, object)
+      assert {:error, :object_exists} = Storage.put_loose_object(repo, object)
 
-      assert {:ok, ^object} = Repository.get_object(repo, @test_content_id)
+      assert {:ok, ^object} = Storage.get_object(repo, @test_content_id)
       assert Object.valid?(object)
     end
   end

--- a/test/xgit/repository/on_disk/get_object_test.exs
+++ b/test/xgit/repository/on_disk/get_object_test.exs
@@ -3,8 +3,8 @@ defmodule Xgit.Repository.OnDisk.GetObjectTest do
 
   alias Xgit.Core.ContentSource
   alias Xgit.Core.Object
-  alias Xgit.Repository
   alias Xgit.Repository.OnDisk
+  alias Xgit.Repository.Storage
 
   describe "get_object/2" do
     test "happy path: can read from command-line git (small file)", %{ref: ref} do
@@ -19,7 +19,7 @@ defmodule Xgit.Repository.OnDisk.GetObjectTest do
 
       assert {:ok,
               %Object{type: :blob, content: test_content, size: 13, id: ^test_content_id} = object} =
-               Repository.get_object(repo, test_content_id)
+               Storage.get_object(repo, test_content_id)
 
       rendered_content =
         test_content
@@ -48,7 +48,7 @@ defmodule Xgit.Repository.OnDisk.GetObjectTest do
 
       assert {:ok,
               %Object{type: :blob, content: test_content, size: 6000, id: ^content_id} = object} =
-               Repository.get_object(repo, content_id)
+               Storage.get_object(repo, content_id)
 
       assert Object.valid?(object)
 
@@ -65,7 +65,7 @@ defmodule Xgit.Repository.OnDisk.GetObjectTest do
       assert {:ok, repo} = OnDisk.start_link(work_dir: ref)
 
       assert {:error, :not_found} =
-               Repository.get_object(repo, "5cb5d77be2d92c7368038dac67e648a69e0a654d")
+               Storage.get_object(repo, "5cb5d77be2d92c7368038dac67e648a69e0a654d")
     end
 
     test "error: invalid object (not ZIP compressed)", %{xgit: xgit} do
@@ -132,6 +132,6 @@ defmodule Xgit.Repository.OnDisk.GetObjectTest do
     assert {:ok, repo} = OnDisk.start_link(work_dir: xgit)
 
     assert {:error, :invalid_object} =
-             Repository.get_object(repo, "5cb5d77be2d92c7368038dac67e648a69e0a654d")
+             Storage.get_object(repo, "5cb5d77be2d92c7368038dac67e648a69e0a654d")
   end
 end

--- a/test/xgit/repository/on_disk/has_all_object_ids_test.exs
+++ b/test/xgit/repository/on_disk/has_all_object_ids_test.exs
@@ -2,8 +2,8 @@ defmodule Xgit.Repository.OnDisk.HasAllObjectIdsTest do
   use Xgit.GitInitTestCase, async: true
 
   alias Xgit.Core.Object
-  alias Xgit.Repository
   alias Xgit.Repository.OnDisk
+  alias Xgit.Repository.Storage
 
   describe "has_all_object_ids?/2" do
     @test_content 'test content\n'
@@ -14,7 +14,7 @@ defmodule Xgit.Repository.OnDisk.HasAllObjectIdsTest do
       assert {:ok, repo} = OnDisk.start_link(work_dir: xgit)
 
       object = %Object{type: :blob, content: @test_content, size: 13, id: @test_content_id}
-      assert :ok = Repository.put_loose_object(repo, object)
+      assert :ok = Storage.put_loose_object(repo, object)
 
       # Yes, the hash is wrong, but we'll ignore that for now.
       object = %Object{
@@ -24,22 +24,22 @@ defmodule Xgit.Repository.OnDisk.HasAllObjectIdsTest do
         id: "c1e116090ad56f172370351ab3f773eb0f1fe89e"
       }
 
-      assert :ok = Repository.put_loose_object(repo, object)
+      assert :ok = Storage.put_loose_object(repo, object)
 
       {:ok, repo: repo}
     end
 
     test "happy path: zero object IDs", %{repo: repo} do
-      assert true == Repository.has_all_object_ids?(repo, [])
+      assert true == Storage.has_all_object_ids?(repo, [])
     end
 
     test "happy path: one object ID", %{repo: repo} do
-      assert true == Repository.has_all_object_ids?(repo, [@test_content_id])
+      assert true == Storage.has_all_object_ids?(repo, [@test_content_id])
     end
 
     test "happy path: two object IDs", %{repo: repo} do
       assert true ==
-               Repository.has_all_object_ids?(repo, [
+               Storage.has_all_object_ids?(repo, [
                  @test_content_id,
                  "c1e116090ad56f172370351ab3f773eb0f1fe89e"
                ])
@@ -47,7 +47,7 @@ defmodule Xgit.Repository.OnDisk.HasAllObjectIdsTest do
 
     test "happy path: partial match", %{repo: repo} do
       assert false ==
-               Repository.has_all_object_ids?(repo, [
+               Storage.has_all_object_ids?(repo, [
                  @test_content_id,
                  "b9e3a9e3ea7dde01d652f899a783b75a1518564c"
                ])
@@ -55,7 +55,7 @@ defmodule Xgit.Repository.OnDisk.HasAllObjectIdsTest do
 
     test "happy path: no match", %{repo: repo} do
       assert false ==
-               Repository.has_all_object_ids?(repo, [
+               Storage.has_all_object_ids?(repo, [
                  @test_content_id,
                  "6ee878a55ed36e2cda2c68452d2336ce3bd692d1"
                ])

--- a/test/xgit/repository/on_disk/put_loose_object_test.exs
+++ b/test/xgit/repository/on_disk/put_loose_object_test.exs
@@ -4,8 +4,8 @@ defmodule Xgit.Repository.OnDisk.PutLooseObjectTest do
   alias Xgit.Core.ContentSource
   alias Xgit.Core.FileContentSource
   alias Xgit.Core.Object
-  alias Xgit.Repository
   alias Xgit.Repository.OnDisk
+  alias Xgit.Repository.Storage
 
   import FolderDiff
 
@@ -25,13 +25,13 @@ defmodule Xgit.Repository.OnDisk.PutLooseObjectTest do
       assert {:ok, repo} = OnDisk.start_link(work_dir: xgit)
 
       object = %Object{type: :blob, content: @test_content, size: 13, id: @test_content_id}
-      assert :ok = Repository.put_loose_object(repo, object)
+      assert :ok = Storage.put_loose_object(repo, object)
 
       assert_folders_are_equal(ref, xgit)
 
       assert {:ok,
               %Object{type: :blob, content: content_read_back, size: 13, id: @test_content_id} =
-                object2} = Repository.get_object(repo, @test_content_id)
+                object2} = Storage.get_object(repo, @test_content_id)
 
       assert Object.valid?(object2)
 
@@ -62,7 +62,7 @@ defmodule Xgit.Repository.OnDisk.PutLooseObjectTest do
 
       fcs = FileContentSource.new(path)
       object = %Object{type: :blob, content: fcs, size: ContentSource.length(fcs), id: content_id}
-      assert :ok = Repository.put_loose_object(repo, object)
+      assert :ok = Storage.put_loose_object(repo, object)
 
       assert_folders_are_equal(ref, xgit)
     end
@@ -76,7 +76,7 @@ defmodule Xgit.Repository.OnDisk.PutLooseObjectTest do
       File.write!(objects_dir, "sand in the gears")
 
       object = %Object{type: :blob, content: @test_content, size: 13, id: @test_content_id}
-      assert {:error, :cant_create_file} = Repository.put_loose_object(repo, object)
+      assert {:error, :cant_create_file} = Storage.put_loose_object(repo, object)
     end
 
     test "error: object exists already", %{xgit: xgit} do
@@ -92,7 +92,7 @@ defmodule Xgit.Repository.OnDisk.PutLooseObjectTest do
       )
 
       object = %Object{type: :blob, content: @test_content, size: 13, id: @test_content_id}
-      assert {:error, :object_exists} = Repository.put_loose_object(repo, object)
+      assert {:error, :object_exists} = Storage.put_loose_object(repo, object)
     end
   end
 end

--- a/test/xgit/repository/on_disk_test.exs
+++ b/test/xgit/repository/on_disk_test.exs
@@ -1,8 +1,8 @@
 defmodule Xgit.Repository.OnDiskTest do
   use Xgit.GitInitTestCase, async: true
 
-  alias Xgit.Repository
   alias Xgit.Repository.OnDisk
+  alias Xgit.Repository.Storage
   alias Xgit.Repository.WorkingTree
 
   import ExUnit.CaptureLog
@@ -13,9 +13,9 @@ defmodule Xgit.Repository.OnDiskTest do
 
       assert {:ok, repo} = OnDisk.start_link(work_dir: xgit)
       assert is_pid(repo)
-      assert Repository.valid?(repo)
+      assert Storage.valid?(repo)
 
-      assert working_tree = Repository.default_working_tree(repo)
+      assert working_tree = Storage.default_working_tree(repo)
       assert is_pid(working_tree)
       assert WorkingTree.valid?(working_tree)
     end

--- a/test/xgit/repository/working_tree/dir_cache_test.exs
+++ b/test/xgit/repository/working_tree/dir_cache_test.exs
@@ -2,9 +2,9 @@ defmodule Xgit.Repository.WorkingTree.DirCacheTest do
   use Xgit.GitInitTestCase, async: true
 
   alias Xgit.Core.DirCache
-  alias Xgit.Repository
   alias Xgit.Repository.InMemory
   alias Xgit.Repository.OnDisk
+  alias Xgit.Repository.Storage
   alias Xgit.Repository.WorkingTree
 
   describe "dir_cache/1" do
@@ -46,7 +46,7 @@ defmodule Xgit.Repository.WorkingTree.DirCacheTest do
         )
 
       {:ok, repo} = OnDisk.start_link(work_dir: ref)
-      working_tree = Repository.default_working_tree(repo)
+      working_tree = Storage.default_working_tree(repo)
 
       assert {:ok, %DirCache{entry_count: 0} = dir_cache} = WorkingTree.dir_cache(working_tree)
       assert DirCache.valid?(dir_cache)
@@ -82,7 +82,7 @@ defmodule Xgit.Repository.WorkingTree.DirCacheTest do
         )
 
       {:ok, repo} = OnDisk.start_link(work_dir: ref)
-      working_tree = Repository.default_working_tree(repo)
+      working_tree = Storage.default_working_tree(repo)
 
       assert {:ok, %DirCache{} = dir_cache} = WorkingTree.dir_cache(working_tree)
       assert DirCache.valid?(dir_cache)
@@ -174,7 +174,7 @@ defmodule Xgit.Repository.WorkingTree.DirCacheTest do
       # ^ WRONG! Should be a file, not a directory.
 
       {:ok, repo} = OnDisk.start_link(work_dir: xgit)
-      working_tree = Repository.default_working_tree(repo)
+      working_tree = Storage.default_working_tree(repo)
 
       assert {:error, :eisdir} = WorkingTree.dir_cache(working_tree)
     end
@@ -188,7 +188,7 @@ defmodule Xgit.Repository.WorkingTree.DirCacheTest do
     File.write!(index_path, iodata)
 
     {:ok, repo} = OnDisk.start_link(work_dir: xgit)
-    working_tree = Repository.default_working_tree(repo)
+    working_tree = Storage.default_working_tree(repo)
 
     WorkingTree.dir_cache(working_tree)
   end

--- a/test/xgit/repository/working_tree/read_tree_test.exs
+++ b/test/xgit/repository/working_tree/read_tree_test.exs
@@ -5,8 +5,8 @@ defmodule Xgit.Repository.WorkingTree.ReadTreeTest do
   alias Xgit.Core.DirCache.Entry
   alias Xgit.GitInitTestCase
   alias Xgit.Plumbing.UpdateIndex.CacheInfo
-  alias Xgit.Repository
   alias Xgit.Repository.OnDisk
+  alias Xgit.Repository.Storage
   alias Xgit.Repository.WorkingTree
 
   describe "read_tree/3" do
@@ -370,7 +370,7 @@ defmodule Xgit.Repository.WorkingTree.ReadTreeTest do
       {output, 0} = System.cmd("git", ["write-tree", "--missing-ok"], cd: xgit)
       tree_object_id = String.trim(output)
 
-      working_tree = Repository.default_working_tree(repo)
+      working_tree = Storage.default_working_tree(repo)
 
       assert {:error, :objects_missing} = WorkingTree.read_tree(working_tree, tree_object_id)
     end
@@ -381,7 +381,7 @@ defmodule Xgit.Repository.WorkingTree.ReadTreeTest do
       :ok = OnDisk.create(xgit)
       {:ok, repo} = OnDisk.start_link(work_dir: xgit)
 
-      working_tree = Repository.default_working_tree(repo)
+      working_tree = Storage.default_working_tree(repo)
 
       assert_raise ArgumentError,
                    ~s(Xgit.Repository.WorkingTree.read_tree/3: missing_ok? "sure" is invalid),
@@ -432,7 +432,7 @@ defmodule Xgit.Repository.WorkingTree.ReadTreeTest do
       File.mkdir_p!(index_path)
 
       {:ok, repo} = OnDisk.start_link(work_dir: xgit)
-      working_tree = Repository.default_working_tree(repo)
+      working_tree = Storage.default_working_tree(repo)
 
       assert {:error, :eisdir} =
                WorkingTree.read_tree(working_tree, tree_object_id, missing_ok?: true)
@@ -453,7 +453,7 @@ defmodule Xgit.Repository.WorkingTree.ReadTreeTest do
 
       {:ok, repo} = OnDisk.start_link(work_dir: ref)
 
-      working_tree = Repository.default_working_tree(repo)
+      working_tree = Storage.default_working_tree(repo)
 
       assert :ok = WorkingTree.read_tree(working_tree, tree_object_id, opts)
       assert {:ok, dir_cache} = WorkingTree.dir_cache(working_tree)

--- a/test/xgit/repository/working_tree/reset_dir_cache_test.exs
+++ b/test/xgit/repository/working_tree/reset_dir_cache_test.exs
@@ -2,8 +2,8 @@ defmodule Xgit.Repository.WorkingTree.ResetDirCacheTest do
   use Xgit.GitInitTestCase, async: true
 
   alias Xgit.Core.DirCache
-  alias Xgit.Repository
   alias Xgit.Repository.OnDisk
+  alias Xgit.Repository.Storage
   alias Xgit.Repository.WorkingTree
 
   import FolderDiff
@@ -41,7 +41,7 @@ defmodule Xgit.Repository.WorkingTree.ResetDirCacheTest do
 
       assert :ok = OnDisk.create(xgit)
       {:ok, repo} = OnDisk.start_link(work_dir: xgit)
-      working_tree = Repository.default_working_tree(repo)
+      working_tree = Storage.default_working_tree(repo)
 
       assert :ok = WorkingTree.reset_dir_cache(working_tree)
 
@@ -80,7 +80,7 @@ defmodule Xgit.Repository.WorkingTree.ResetDirCacheTest do
 
       assert :ok = OnDisk.create(xgit)
       {:ok, repo} = OnDisk.start_link(work_dir: xgit)
-      working_tree = Repository.default_working_tree(repo)
+      working_tree = Storage.default_working_tree(repo)
 
       assert :ok =
                WorkingTree.update_dir_cache(
@@ -165,7 +165,7 @@ defmodule Xgit.Repository.WorkingTree.ResetDirCacheTest do
       File.mkdir_p!(index)
 
       {:ok, repo} = OnDisk.start_link(work_dir: xgit)
-      working_tree = Repository.default_working_tree(repo)
+      working_tree = Storage.default_working_tree(repo)
 
       assert {:error, :eisdir} = WorkingTree.reset_dir_cache(working_tree)
     end

--- a/test/xgit/repository/working_tree/update_dir_cache_test.exs
+++ b/test/xgit/repository/working_tree/update_dir_cache_test.exs
@@ -2,8 +2,8 @@ defmodule Xgit.Repository.WorkingTree.UpdateDirCacheTest do
   use Xgit.GitInitTestCase, async: true
 
   alias Xgit.Core.DirCache
-  alias Xgit.Repository
   alias Xgit.Repository.OnDisk
+  alias Xgit.Repository.Storage
   alias Xgit.Repository.WorkingTree
 
   import FolderDiff
@@ -41,7 +41,7 @@ defmodule Xgit.Repository.WorkingTree.UpdateDirCacheTest do
 
       assert :ok = OnDisk.create(xgit)
       {:ok, repo} = OnDisk.start_link(work_dir: xgit)
-      working_tree = Repository.default_working_tree(repo)
+      working_tree = Storage.default_working_tree(repo)
 
       assert :ok = WorkingTree.update_dir_cache(working_tree, [], [])
 
@@ -80,7 +80,7 @@ defmodule Xgit.Repository.WorkingTree.UpdateDirCacheTest do
 
       assert :ok = OnDisk.create(xgit)
       {:ok, repo} = OnDisk.start_link(work_dir: xgit)
-      working_tree = Repository.default_working_tree(repo)
+      working_tree = Storage.default_working_tree(repo)
 
       assert :ok =
                WorkingTree.update_dir_cache(
@@ -181,7 +181,7 @@ defmodule Xgit.Repository.WorkingTree.UpdateDirCacheTest do
         )
 
       {:ok, repo} = OnDisk.start_link(work_dir: xgit)
-      working_tree = Repository.default_working_tree(repo)
+      working_tree = Storage.default_working_tree(repo)
 
       assert :ok =
                assert(
@@ -204,7 +204,7 @@ defmodule Xgit.Repository.WorkingTree.UpdateDirCacheTest do
       File.write!(index, 'DIRX12345678901234567890')
 
       {:ok, repo} = OnDisk.start_link(work_dir: xgit)
-      working_tree = Repository.default_working_tree(repo)
+      working_tree = Storage.default_working_tree(repo)
 
       assert {:error, :invalid_format} =
                WorkingTree.update_dir_cache(

--- a/test/xgit/repository/working_tree/write_tree_test.exs
+++ b/test/xgit/repository/working_tree/write_tree_test.exs
@@ -4,8 +4,8 @@ defmodule Xgit.Repository.WorkingTree.WriteTreeTest do
   alias Xgit.Core.DirCache.Entry
   alias Xgit.GitInitTestCase
   alias Xgit.Plumbing.HashObject
-  alias Xgit.Repository
   alias Xgit.Repository.OnDisk
+  alias Xgit.Repository.Storage
   alias Xgit.Repository.WorkingTree
 
   import FolderDiff
@@ -33,7 +33,7 @@ defmodule Xgit.Repository.WorkingTree.WriteTreeTest do
             )
         end,
         fn xgit_repo ->
-          working_tree = Repository.default_working_tree(xgit_repo)
+          working_tree = Storage.default_working_tree(xgit_repo)
 
           assert :ok =
                    WorkingTree.update_dir_cache(
@@ -72,7 +72,7 @@ defmodule Xgit.Repository.WorkingTree.WriteTreeTest do
       :ok = OnDisk.create(xgit)
       {:ok, repo} = OnDisk.start_link(work_dir: xgit)
 
-      working_tree = Repository.default_working_tree(repo)
+      working_tree = Storage.default_working_tree(repo)
 
       assert :ok =
                WorkingTree.update_dir_cache(
@@ -124,7 +124,7 @@ defmodule Xgit.Repository.WorkingTree.WriteTreeTest do
             )
         end,
         fn xgit_repo ->
-          working_tree = Repository.default_working_tree(xgit_repo)
+          working_tree = Storage.default_working_tree(xgit_repo)
 
           assert :ok =
                    WorkingTree.update_dir_cache(
@@ -231,7 +231,7 @@ defmodule Xgit.Repository.WorkingTree.WriteTreeTest do
             )
         end,
         fn xgit_repo ->
-          working_tree = Repository.default_working_tree(xgit_repo)
+          working_tree = Storage.default_working_tree(xgit_repo)
 
           assert :ok =
                    WorkingTree.update_dir_cache(
@@ -446,7 +446,7 @@ defmodule Xgit.Repository.WorkingTree.WriteTreeTest do
             )
         end,
         fn xgit_repo ->
-          working_tree = Repository.default_working_tree(xgit_repo)
+          working_tree = Storage.default_working_tree(xgit_repo)
 
           assert :ok =
                    WorkingTree.update_dir_cache(
@@ -609,7 +609,7 @@ defmodule Xgit.Repository.WorkingTree.WriteTreeTest do
           # Ideally, this should not reach up-level to plumbing, but I'm cheating here today.
           {:ok, object_id} = HashObject.run("test content\n", repo: xgit_repo, write?: true)
 
-          working_tree = Repository.default_working_tree(xgit_repo)
+          working_tree = Storage.default_working_tree(xgit_repo)
 
           assert :ok =
                    WorkingTree.update_dir_cache(
@@ -649,7 +649,7 @@ defmodule Xgit.Repository.WorkingTree.WriteTreeTest do
 
       :ok
 
-      working_tree = Repository.default_working_tree(repo)
+      working_tree = Storage.default_working_tree(repo)
 
       assert :ok =
                WorkingTree.update_dir_cache(
@@ -687,7 +687,7 @@ defmodule Xgit.Repository.WorkingTree.WriteTreeTest do
       :ok = OnDisk.create(xgit)
       {:ok, repo} = OnDisk.start_link(work_dir: xgit)
 
-      working_tree = Repository.default_working_tree(repo)
+      working_tree = Storage.default_working_tree(repo)
 
       :ok =
         WorkingTree.update_dir_cache(
@@ -838,7 +838,7 @@ defmodule Xgit.Repository.WorkingTree.WriteTreeTest do
 
       {:ok, repo} = OnDisk.start_link(work_dir: xgit)
 
-      working_tree = Repository.default_working_tree(repo)
+      working_tree = Storage.default_working_tree(repo)
 
       assert {:error, :invalid_format} = WorkingTree.write_tree(working_tree, missing_ok?: true)
     end
@@ -849,7 +849,7 @@ defmodule Xgit.Repository.WorkingTree.WriteTreeTest do
       :ok = OnDisk.create(xgit)
       {:ok, repo} = OnDisk.start_link(work_dir: xgit)
 
-      working_tree = Repository.default_working_tree(repo)
+      working_tree = Storage.default_working_tree(repo)
 
       assert_raise ArgumentError,
                    ~s(Xgit.Repository.WorkingTree.write_tree/2: missing_ok? "sure" is invalid),
@@ -884,7 +884,7 @@ defmodule Xgit.Repository.WorkingTree.WriteTreeTest do
       :ok = OnDisk.create(xgit)
       {:ok, repo} = OnDisk.start_link(work_dir: xgit)
 
-      working_tree = Repository.default_working_tree(repo)
+      working_tree = Storage.default_working_tree(repo)
 
       :ok =
         WorkingTree.update_dir_cache(
@@ -902,7 +902,7 @@ defmodule Xgit.Repository.WorkingTree.WriteTreeTest do
       :ok = OnDisk.create(xgit)
       {:ok, repo} = OnDisk.start_link(work_dir: xgit)
 
-      working_tree = Repository.default_working_tree(repo)
+      working_tree = Storage.default_working_tree(repo)
       :ok = WorkingTree.update_dir_cache(working_tree, [@valid_entry], [])
 
       objects_path = Path.join([xgit, ".git", "objects"])
@@ -918,7 +918,7 @@ defmodule Xgit.Repository.WorkingTree.WriteTreeTest do
       :ok = OnDisk.create(xgit)
       {:ok, repo} = OnDisk.start_link(work_dir: xgit)
 
-      working_tree = Repository.default_working_tree(repo)
+      working_tree = Storage.default_working_tree(repo)
 
       assert_raise ArgumentError,
                    ~s[Xgit.Repository.WorkingTree.write_tree/2: prefix "a/b/c" is invalid (should be a charlist, not a String)],
@@ -948,7 +948,7 @@ defmodule Xgit.Repository.WorkingTree.WriteTreeTest do
 
       xgit_fn.(repo)
 
-      working_tree = Repository.default_working_tree(repo)
+      working_tree = Storage.default_working_tree(repo)
       assert {:ok, xgit_object_id} = WorkingTree.write_tree(working_tree, opts)
 
       assert_folders_are_equal(


### PR DESCRIPTION
## Changes in This Pull Request

Part 1 of a refactoring and renaming process aimed at making Xgit more approachable.

Placing this deeper in the hierarchy suggests that this module:

(1) should typically be considered an implementation detail, and
(2) is of interest primarily to those who wish to implement alternative storage mechanisms.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] There is test coverage for all changes.
- ~All cases where a literal value is returned use the `cover` macro to force code coverage.~ _n/a_
- ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
