### PR TITLE
Implement `Xgit.Repository.Plumbing.get_symbolic_ref/2`.

### DIFF
--- a/lib/xgit/repository/plumbing.ex
+++ b/lib/xgit/repository/plumbing.ex
@@ -902,6 +902,53 @@ defmodule Xgit.Repository.Plumbing do
   end
 
   @typedoc ~S"""
+  Reason codes that can be returned by `get_symbolic_ref/2`.
+  """
+  @type get_symbolic_ref_reason :: :invalid_repository | Storage.get_ref_reason()
+
+  @doc ~S"""
+  Returns the target ref for an existing symbolic ref.
+
+  Analogous to the one-argument form of
+  [`git symbolic-ref`](https://git-scm.com/docs/git-symbolic-ref).
+
+  ## Parameters
+
+  `repository` is the `Xgit.Repository.Storage` (PID) in which to create the symbolic reference.
+
+  `name` is the name of the symbolic reference to read. (See `t/Xgit.Ref.name`.)
+
+  ## Return Value
+
+  `{:ok, ref_name}` if read successfully. `ref_name` is the name of the targeted reference.
+
+  `{:error, :invalid_repository}` if `repository` doesn't represent a valid
+  `Xgit.Repository.Storage` process.
+
+  `{:error, :not_symbolic_ref}` if `name` refers to a ref that is not a symbolic ref.
+
+  Reason codes may also come from the following functions:
+
+  * `Xgit.Repository.Storage.get_ref/3`
+  """
+  @spec get_symbolic_ref(
+          repository :: Storage.t(),
+          name :: Ref.name()
+        ) :: {:ok, name :: Ref.name()} | {:error, reason :: get_symbolic_ref_reason}
+  def get_symbolic_ref(repository, name) when is_pid(repository) and is_binary(name) do
+    with {:valid?, true} <- {:valid?, Storage.valid?(repository)},
+         {:ok, %Ref{target: target}} when is_binary(target) <-
+           Storage.get_ref(repository, name, follow_link?: false) do
+      cover {:ok, String.replace_prefix(target, "ref: ", "")}
+    else
+      {:valid?, _} -> cover {:error, :invalid_repository}
+      {:error, :enotdir} -> cover {:error, :not_found}
+      {:error, reason} -> cover {:error, reason}
+      {:ok, _} -> cover {:ok, :not_symbolic_ref}
+    end
+  end
+
+  @typedoc ~S"""
   Reason codes that can be returned by `put_symbolic_ref/4`.
   """
   @type put_symbolic_ref_reason :: :invalid_repository | Storage.put_ref_reason()

--- a/test/xgit/repository/plumbing/get_symbolic_ref_test.exs
+++ b/test/xgit/repository/plumbing/get_symbolic_ref_test.exs
@@ -1,0 +1,50 @@
+defmodule Xgit.Repository.Plumbing.GetSymbolicRefTest do
+  use ExUnit.Case, async: true
+
+  # alias Xgit.Ref
+  alias Xgit.Repository.Plumbing
+  alias Xgit.Test.OnDiskRepoTestCase
+
+  describe "get_symbolic_ref/2" do
+    test "happy path: default HEAD branch points to master" do
+      %{xgit_repo: repo} = OnDiskRepoTestCase.repo!()
+      assert {:ok, "refs/heads/master"} = Plumbing.get_symbolic_ref(repo, "HEAD")
+    end
+
+    test "happy path: HEAD branch points to non-existent branch" do
+      %{xgit_repo: repo} = OnDiskRepoTestCase.repo!()
+
+      assert :ok = Plumbing.put_symbolic_ref(repo, "HEAD", "refs/heads/nope")
+
+      assert {:ok, "refs/heads/nope"} = Plumbing.get_symbolic_ref(repo, "HEAD")
+    end
+
+    test "error: posix error (dir where file should be)" do
+      %{xgit_repo: repo, xgit_path: xgit_path} = OnDiskRepoTestCase.repo!()
+
+      File.mkdir_p!(Path.join(xgit_path, ".git/refs/heads/whatever"))
+
+      assert {:error, :eisdir} = Plumbing.get_symbolic_ref(repo, "refs/heads/whatever")
+    end
+
+    test "error: posix error (file where dir should be)" do
+      %{xgit_repo: repo, xgit_path: xgit_path} = OnDiskRepoTestCase.repo!()
+
+      File.write!(Path.join(xgit_path, ".git/refs/heads/sub"), "oops, not a directory")
+
+      assert {:error, :not_found} = Plumbing.get_symbolic_ref(repo, "refs/heads/sub/master")
+    end
+
+    test "error: repository invalid (not PID)" do
+      assert_raise FunctionClauseError, fn ->
+        Plumbing.get_symbolic_ref("xgit repo", "HEAD")
+      end
+    end
+
+    test "error: repository invalid (PID, but not repo)" do
+      {:ok, not_repo} = GenServer.start_link(NotValid, nil)
+
+      assert {:error, :invalid_repository} = Plumbing.get_symbolic_ref(not_repo, "HEAD")
+    end
+  end
+end

--- a/test/xgit/repository/plumbing/get_symbolic_ref_test.exs
+++ b/test/xgit/repository/plumbing/get_symbolic_ref_test.exs
@@ -1,7 +1,6 @@
 defmodule Xgit.Repository.Plumbing.GetSymbolicRefTest do
   use ExUnit.Case, async: true
 
-  # alias Xgit.Ref
   alias Xgit.Repository.Plumbing
   alias Xgit.Test.OnDiskRepoTestCase
 
@@ -17,6 +16,22 @@ defmodule Xgit.Repository.Plumbing.GetSymbolicRefTest do
       assert :ok = Plumbing.put_symbolic_ref(repo, "HEAD", "refs/heads/nope")
 
       assert {:ok, "refs/heads/nope"} = Plumbing.get_symbolic_ref(repo, "HEAD")
+    end
+
+    test "error: not a symbolic references" do
+      %{xgit_repo: repo} = OnDiskRepoTestCase.repo!()
+
+      {:ok, commit_id_master} =
+        Plumbing.hash_object('shhh... not really a commit',
+          repo: repo,
+          type: :commit,
+          validate?: false,
+          write?: true
+        )
+
+      assert :ok = Plumbing.update_ref(repo, "HEAD", commit_id_master)
+
+      assert {:error, :not_symbolic_ref} = Plumbing.get_symbolic_ref(repo, "refs/heads/master")
     end
 
     test "error: posix error (dir where file should be)" do


### PR DESCRIPTION
## Changes in This Pull Request
This is an API equivalent to the one-argument form of `git symbolic-ref`.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] There is test coverage for all changes.
- [x] All cases where a literal value is returned use the `cover` macro to force code coverage.
- ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
