### PR TITLE
[API BREAKING] Rework Xgit.Repository.Plumbing.delete_ref/3 to add follow_link? option.

### DIFF
--- a/lib/xgit/repository/storage.ex
+++ b/lib/xgit/repository/storage.ex
@@ -344,12 +344,12 @@ defmodule Xgit.Repository.Storage do
 
   ## Options
 
+  `follow_link?`: (default: `true`) `true` to follow symbolic refs
+
   `old_target`: If present, a ref with this name must already exist and the `target`
   value must match the object ID provided in this option.
 
   ## TO DO
-
-  `follow_link?` option. https://github.com/elixir-git/xgit/issues/249
 
   Support for ref log. https://github.com/elixir-git/xgit/issues/224
 
@@ -366,7 +366,10 @@ defmodule Xgit.Repository.Storage do
   `{:error, :old_target_not_matched}` if `old_target` was specified and the target ref points
   to a different object ID or did not exist.
   """
-  @spec delete_ref(repository :: t, name :: Ref.name(), old_target: ObjectId.t()) ::
+  @spec delete_ref(repository :: t, name :: Ref.name(),
+          follow_link?: boolean,
+          old_target: ObjectId.t()
+        ) ::
           :ok | {:error, reason :: delete_ref_reason}
   def delete_ref(repository, name, opts \\ [])
       when is_pid(repository) and is_binary(name) and is_list(opts) do
@@ -384,6 +387,8 @@ defmodule Xgit.Repository.Storage do
 
   ## Options
 
+  `follow_link?`: `true` to follow symbolic refs
+
   `old_target`: If present, a ref with this name must already exist and the `target`
   value must match the object ID provided in this option.
 
@@ -397,7 +402,10 @@ defmodule Xgit.Repository.Storage do
   Should return `{:error, :old_target_not_matched}` if `old_target` was specified and the
   target ref points to a different object ID or the ref did not exist.
   """
-  @callback handle_delete_ref(state :: any, name :: Ref.name(), old_target: ObjectId.t()) ::
+  @callback handle_delete_ref(state :: any, name :: Ref.name(),
+              follow_link?: boolean,
+              old_target: ObjectId.t()
+            ) ::
               {:ok, state :: any} | {:error, reason :: delete_ref_reason, state :: any}
 
   @typedoc ~S"""


### PR DESCRIPTION
## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] There is test coverage for all changes.
- [x] All cases where a literal value is returned use the `cover` macro to force code coverage.
- ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
