### PR TITLE
Implement `Xgit.Repository.Plumbing.delete_symbolic_ref/2`.

### DIFF
--- a/lib/xgit/repository/plumbing.ex
+++ b/lib/xgit/repository/plumbing.ex
@@ -1037,7 +1037,7 @@ defmodule Xgit.Repository.Plumbing do
       when is_pid(repository) and is_binary(name) do
     with {:valid?, true} <- {:valid?, Storage.valid?(repository)},
          :ok <- Storage.delete_ref(repository, name, follow_link?: false) do
-      :ok
+      cover :ok
     else
       {:valid?, _} -> cover {:error, :invalid_repository}
       {:error, reason} -> cover {:error, reason}

--- a/lib/xgit/repository/plumbing.ex
+++ b/lib/xgit/repository/plumbing.ex
@@ -1002,6 +1002,48 @@ defmodule Xgit.Repository.Plumbing do
     end
   end
 
+  @typedoc ~S"""
+  Reason codes that can be returned by `delete_symbolic_ref/2`.
+  """
+  @type delete_symbolic_ref_reason :: :invalid_repository | Storage.delete_ref_reason()
+
+  @doc ~S"""
+  Deletes a symbolic ref.
+
+  Analogous to [`git symbolic-ref --delete`](https://git-scm.com/docs/git-symbolic-ref#Documentation/git-symbolic-ref.txt---delete).
+
+  ## Parameters
+
+  `repository` is the `Xgit.Repository.Storage` (PID) in which to create the symbolic reference.
+
+  `name` is the name of the symbolic reference to delete. (See `t/Xgit.Ref.name`.)
+
+  ## Return Value
+
+  `:ok` if deleted successfully.
+
+  `{:error, :invalid_repository}` if `repository` doesn't represent a valid
+  `Xgit.Repository.Storage` process.
+
+  Reason codes may also come from the following functions:
+
+  * `Xgit.Repository.Storage.delete_ref/3`
+  """
+  @spec delete_symbolic_ref(
+          repository :: Storage.t(),
+          name :: Ref.name()
+        ) :: :ok | {:error, reason :: delete_symbolic_ref_reason}
+  def delete_symbolic_ref(repository, name)
+      when is_pid(repository) and is_binary(name) do
+    with {:valid?, true} <- {:valid?, Storage.valid?(repository)},
+         :ok <- Storage.delete_ref(repository, name, follow_link?: false) do
+      :ok
+    else
+      {:valid?, _} -> cover {:error, :invalid_repository}
+      {:error, reason} -> cover {:error, reason}
+    end
+  end
+
   ## --- Options ---
 
   # Parse working tree and repository from arguments and options.

--- a/test/xgit/repository/plumbing/delete_symbolic_ref_test.exs
+++ b/test/xgit/repository/plumbing/delete_symbolic_ref_test.exs
@@ -1,0 +1,66 @@
+defmodule Xgit.Repository.Plumbing.DeleteSymbolicRefTest do
+  use ExUnit.Case, async: true
+
+  alias Xgit.Repository.Plumbing
+  alias Xgit.Test.OnDiskRepoTestCase
+
+  import FolderDiff
+
+  describe "delete_symbolic_ref/2" do
+    test "happy path: target ref does not exist" do
+      %{xgit_path: path, xgit_repo: repo} = OnDiskRepoTestCase.repo!()
+
+      assert :ok = Plumbing.delete_symbolic_ref(repo, "HEAD")
+
+      refute File.exists?(Path.join(path, ".git/HEAD"))
+    end
+
+    test "error: posix error (dir where file should be)" do
+      %{xgit_repo: repo, xgit_path: xgit_path} = OnDiskRepoTestCase.repo!()
+
+      File.mkdir_p!(Path.join(xgit_path, ".git/refs/heads/whatever"))
+
+      assert {:error, :cant_delete_file} =
+               Plumbing.delete_symbolic_ref(repo, "refs/heads/whatever")
+    end
+
+    test "error: posix error (file where dir should be)" do
+      %{xgit_repo: repo, xgit_path: xgit_path} = OnDiskRepoTestCase.repo!()
+
+      File.write!(Path.join(xgit_path, ".git/refs/heads/sub"), "oops, not a directory")
+
+      assert {:error, :cant_delete_file} =
+               Plumbing.delete_symbolic_ref(repo, "refs/heads/sub/master")
+    end
+
+    test "matches command-line output" do
+      %{xgit_path: xgit_path, xgit_repo: xgit_repo} = OnDiskRepoTestCase.repo!()
+      %{xgit_path: ref_path} = OnDiskRepoTestCase.repo!()
+
+      :ok = Plumbing.put_symbolic_ref(xgit_repo, "refs/heads/source", "refs/heads/other")
+
+      {_, 0} =
+        System.cmd("git", ["symbolic-ref", "refs/heads/source", "refs/heads/other"], cd: ref_path)
+
+      assert_folders_are_equal(ref_path, xgit_path)
+
+      {_, 0} = System.cmd("git", ["symbolic-ref", "--delete", "refs/heads/source"], cd: ref_path)
+
+      assert :ok = Plumbing.delete_symbolic_ref(xgit_repo, "refs/heads/source")
+
+      assert_folders_are_equal(ref_path, xgit_path)
+    end
+
+    test "error: repository invalid (not PID)" do
+      assert_raise FunctionClauseError, fn ->
+        Plumbing.delete_symbolic_ref("xgit repo", "HEAD")
+      end
+    end
+
+    test "error: repository invalid (PID, but not repo)" do
+      {:ok, not_repo} = GenServer.start_link(NotValid, nil)
+
+      assert {:error, :invalid_repository} = Plumbing.delete_symbolic_ref(not_repo, "HEAD")
+    end
+  end
+end


### PR DESCRIPTION
## Changes in This Pull Request
This is an API equivalent to `git symbolic-ref --delete`.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] There is test coverage for all changes.
- [x] All cases where a literal value is returned use the `cover` macro to force code coverage.
- ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
