### PR TITLE
Xgit.Tag.from_object/1 should return error if object type is not recognized.

### DIFF
--- a/lib/xgit/tag.ex
+++ b/lib/xgit/tag.ex
@@ -94,7 +94,7 @@ defmodule Xgit.Tag do
     with {:object, {'object', object_id_str, data}} <- {:object, next_header(data)},
          {:object_id, {object_id, []}} <- {:object_id, ObjectId.from_hex_charlist(object_id_str)},
          {:type_str, {'type', type_str, data}} <- {:type_str, next_header(data)},
-         {:type, type} <- {:type, ObjectType.from_bytelist(type_str)},
+         {:type, type} when is_object_type(type) <- {:type, ObjectType.from_bytelist(type_str)},
          {:name, {'tag', [_ | _] = name, data}} <- {:name, next_header(data)},
          {:tagger_id, tagger, data} <- optional_tagger(data),
          message when is_list(message) <- drop_if_lf(data) do

--- a/test/xgit/tag_test.exs
+++ b/test/xgit/tag_test.exs
@@ -248,6 +248,19 @@ defmodule Xgit.TagTest do
                })
     end
 
+    test "invalid: invalid type" do
+      assert {:error, :invalid_tag} =
+               Tag.from_object(%Object{
+                 type: :tag,
+                 content: ~c"""
+                 object be9bfa841874ccc9f2ef7c48d0c76226f89b7189
+                 type bogus
+                 tag test-tag
+                 tagger A. U. Thor <author@localhost> 1 +0000
+                 """
+               })
+    end
+
     test "invalid: no tag header 1" do
       assert {:error, :invalid_tag} =
                Tag.from_object(%Object{


### PR DESCRIPTION
## Changes in This Pull Request
Bug fix: `Xgit.Tag.from_object/1` would return a `Tag` structure with `type: :error` if the `type` field was present, but invalid, in the tag object.

Updated to return `{:error, :invalid_tag}` instead.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- ~All applicable changes have been documented.~ _n/a_
- [x] There is test coverage for all changes.
- ~All cases where a literal value is returned use the `cover` macro to force code coverage.~ _n/a_
- ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
