### PR TITLE
Implement Xgit.Repository.tag/4, our first porcelain-level command.

### DIFF
--- a/lib/xgit/repository.ex
+++ b/lib/xgit/repository.ex
@@ -194,7 +194,7 @@ defmodule Xgit.Repository do
            type: target_type,
            name: String.to_charlist(tag_name),
            tagger: tagger,
-           message: message
+           message: ensure_trailing_newline(message)
          },
          %Object{id: tag_id} = tag_object <- Tag.to_object(tag),
          :ok <- Storage.put_loose_object(repository, tag_object) do
@@ -202,6 +202,14 @@ defmodule Xgit.Repository do
       Storage.put_ref(repository, ref, opts_for_force(force?))
     else
       {:error, reason} -> cover {:error, reason}
+    end
+  end
+
+  defp ensure_trailing_newline(message) do
+    if List.last(message) == 10 do
+      message
+    else
+      message ++ '\n'
     end
   end
 

--- a/lib/xgit/repository.ex
+++ b/lib/xgit/repository.ex
@@ -185,7 +185,7 @@ defmodule Xgit.Repository do
               "Xgit.Repository.tag/4: tagger must be specified for an annotated tag"
 
       PersonIdent.valid?(tagger) ->
-        tagger
+        cover tagger
 
       true ->
         raise ArgumentError,
@@ -223,9 +223,9 @@ defmodule Xgit.Repository do
 
   defp ensure_trailing_newline(message) do
     if List.last(message) == 10 do
-      message
+      cover(message)
     else
-      message ++ '\n'
+      cover(message ++ '\n')
     end
   end
 

--- a/lib/xgit/repository.ex
+++ b/lib/xgit/repository.ex
@@ -208,7 +208,6 @@ defmodule Xgit.Repository do
       ref = %Ref{name: "refs/tags/#{tag_name}", target: tag_id}
       Storage.put_ref(repository, ref, opts_for_force(force?))
     else
-      {:ok, %Ref{}} -> cover {:error, :old_target_not_matched}
       {:error, reason} -> cover {:error, reason}
     end
   end

--- a/lib/xgit/repository.ex
+++ b/lib/xgit/repository.ex
@@ -74,7 +74,7 @@ defmodule Xgit.Repository do
 
     unless Tag.valid_name?(String.to_charlist(tag_name)) do
       raise ArgumentError,
-            "Xgit.Repository.tag/4: tag_name #{tag_name} is invalid"
+            ~s(Xgit.Repository.tag/4: tag_name "#{tag_name}" is invalid)
     end
 
     unless ObjectId.valid?(object) do
@@ -112,8 +112,19 @@ defmodule Xgit.Repository do
       nil ->
         nil
 
+      "" ->
+        raise ArgumentError,
+              "Xgit.Repository.tag/4: message must be non-empty if present"
+
+      message when is_binary(message) ->
+        String.to_charlist(message)
+
       [_ | _] = message ->
         message
+
+      [] ->
+        raise ArgumentError,
+              "Xgit.Repository.tag/4: message must be non-empty if present"
 
       invalid ->
         raise ArgumentError,

--- a/lib/xgit/repository.ex
+++ b/lib/xgit/repository.ex
@@ -9,6 +9,8 @@ defmodule Xgit.Repository do
   The functions implemented in this module correspond to the "plumbing" commands
   implemented by command-line git.
   """
+  import Xgit.Util.ForceCoverage
+
   alias Xgit.ObjectId
   alias Xgit.Ref
   alias Xgit.Repository.Storage
@@ -96,10 +98,10 @@ defmodule Xgit.Repository do
   defp force_from_tag_options(options) do
     case Keyword.get(options, :force?, false) do
       false ->
-        false
+        cover false
 
       true ->
-        true
+        cover true
 
       invalid ->
         raise ArgumentError,
@@ -110,7 +112,7 @@ defmodule Xgit.Repository do
   defp message_from_tag_options(options) do
     case Keyword.get(options, :message) do
       nil ->
-        nil
+        cover nil
 
       "" ->
         raise ArgumentError,
@@ -120,7 +122,7 @@ defmodule Xgit.Repository do
         String.to_charlist(message)
 
       [_ | _] = message ->
-        message
+        cover message
 
       [] ->
         raise ArgumentError,
@@ -138,15 +140,15 @@ defmodule Xgit.Repository do
         is_list(message)
 
       false ->
-        if is_list(message) do
+        if message == nil do
+          cover false
+        else
           raise ArgumentError,
                 "Xgit.Repository.tag/4: annotated?: false can not be specified when message is present"
-        else
-          false
         end
 
       true ->
-        true
+        cover true
 
       invalid ->
         raise ArgumentError,
@@ -161,9 +163,9 @@ defmodule Xgit.Repository do
   defp create_lightweight_tag(repository, tag_name, object, force?) do
     opts =
       if force? do
-        [follow_link?: false]
+        cover follow_link?: false
       else
-        [follow_link?: false, old_target: :new]
+        cover follow_link?: false, old_target: :new
       end
 
     ref = %Ref{name: "refs/tags/#{tag_name}", target: object}

--- a/lib/xgit/repository.ex
+++ b/lib/xgit/repository.ex
@@ -6,8 +6,10 @@ defmodule Xgit.Repository do
   that implements `Xgit.Repository.Storage`. The resulting PID can be used when
   calling functions in this module and `Xgit.Repository.Plumbing`.
 
-  The functions implemented in this module correspond to the "plumbing" commands
+  The functions implemented in this module correspond to the "porcelain" commands
   implemented by command-line git.
+
+  (As of this writing, relatively few of the porcelain commands are implemented.)
   """
   import Xgit.Util.ForceCoverage
 
@@ -34,6 +36,11 @@ defmodule Xgit.Repository do
 
   ## -- Tags --
 
+  @typedoc ~S"""
+  Reason codes that can be returned by `tag/4`.
+  """
+  @type tag_reason :: Storage.put_ref_reason()
+
   @doc ~S"""
   Create a tag object.
 
@@ -43,9 +50,10 @@ defmodule Xgit.Repository do
 
   `repository` is the `Xgit.Repository.Storage` (PID) to search for the object.
 
-  `tag_name` (String.t) is the name to give to the new tag.
+  `tag_name` (`String`) is the name to give to the new tag.
 
-  `object` (ObjectId.t) is the object ID to be pointed to by this tag (typically a `commit` object).
+  `object` (`Xgit.ObjectId`) is the object ID to be pointed to by this tag
+  (typically a `commit` object).
 
   ## Options
 
@@ -53,7 +61,7 @@ defmodule Xgit.Repository do
 
   `force?`: (boolean) true to replace an existing tag (default: `false`)
 
-  `message`: (String.t or bytelist) message to associate with the tag.
+  `message`: (`String` or bytelist) message to associate with the tag.
   * Must be present and non-empty if `:annotated?` is `true`.
   * Implies `annotated?: true`.
 
@@ -63,18 +71,16 @@ defmodule Xgit.Repository do
 
   `:ok` if created successfully.
 
-  `{:error, reason}` if unable.
+  `{:error, reason}` if unable. Reason codes may come from `Xgit.Repository.Storage.put_ref/3`.
 
-  TO DO: Specify reason codes.
-
-  TO DO: Support GPG signatures
+  TO DO: Support GPG signatures. https://github.com/elixir-git/xgit/issues/202
   """
   @spec tag(repository :: t, tag_name :: String.t(), object :: ObjectId.t(),
           annotated?: boolean,
           force?: boolean,
           message: [byte] | String.t(),
           tagger: PersonIdent.t()
-        ) :: :ok
+        ) :: :ok | {:error, reason :: tag_reason}
   def tag(repository, tag_name, object, options \\ [])
       when is_pid(repository) and is_binary(tag_name) and is_binary(object) and is_list(options) do
     repository = Storage.assert_valid(repository)

--- a/lib/xgit/repository.ex
+++ b/lib/xgit/repository.ex
@@ -51,8 +51,8 @@ defmodule Xgit.Repository do
 
   `force?`: (boolean) true to replace an existing tag (default: `false`)
 
-  `message`: (bytelist) message to associate with the tag.
-  * Must be non-empty if `:annotated?` is `true`.
+  `message`: (String.t or bytelist) message to associate with the tag.
+  * Must be present and non-empty if `:annotated?` is `true`.
   * Implies `annotated?: true`.
 
   ## Return Value
@@ -68,7 +68,7 @@ defmodule Xgit.Repository do
   @spec tag(repository :: t, tag_name :: String.t(), object :: ObjectId.t(),
           annotated?: boolean,
           force?: boolean,
-          message: [byte]
+          message: [byte] | String.t()
         ) :: :ok
   def tag(repository, tag_name, object, options \\ [])
       when is_pid(repository) and is_binary(tag_name) and is_binary(object) and is_list(options) do

--- a/lib/xgit/repository.ex
+++ b/lib/xgit/repository.ex
@@ -135,10 +135,7 @@ defmodule Xgit.Repository do
   end
 
   defp annotated_from_tag_options(options, message) do
-    case Keyword.get(options, :annotated?, is_list(message)) do
-      nil ->
-        is_list(message)
-
+    case Keyword.get(options, :annotated?, message != nil) do
       false ->
         if message == nil do
           cover false
@@ -148,7 +145,12 @@ defmodule Xgit.Repository do
         end
 
       true ->
-        cover true
+        if message == nil do
+          raise ArgumentError,
+                "Xgit.Repository.tag/4: annotated?: true can not be specified without message"
+        else
+          cover true
+        end
 
       invalid ->
         raise ArgumentError,

--- a/test/xgit/repository/tag_test.exs
+++ b/test/xgit/repository/tag_test.exs
@@ -1,24 +1,22 @@
 defmodule Xgit.Repository.TagTest do
   use ExUnit.Case, async: true
 
-  # alias Xgit.PersonIdent
+  alias Xgit.PersonIdent
   alias Xgit.Repository
   alias Xgit.Repository.InMemory
   alias Xgit.Repository.InvalidRepositoryError
-  # alias Xgit.Repository.Plumbing
-  # alias Xgit.Repository.Storage
   alias Xgit.Test.OnDiskRepoTestCase
 
   import FolderDiff
   import Xgit.Test.OnDiskRepoTestCase, only: [setup_with_valid_parent_commit!: 0]
 
   describe "tag/4" do
-    # @valid_pi %PersonIdent{
-    #   name: "A. U. Thor",
-    #   email: "author@example.com",
-    #   when: 1_142_878_449_000,
-    #   tz_offset: 150
-    # }
+    @valid_pi %PersonIdent{
+      name: "A. U. Thor",
+      email: "author@example.com",
+      when: 1_142_878_449_000,
+      tz_offset: 150
+    }
 
     @env OnDiskRepoTestCase.sample_commit_env()
 
@@ -157,6 +155,28 @@ defmodule Xgit.Repository.TagTest do
 
       assert :ok =
                Repository.tag(xgit_repo, "sample-tag", commit2_id, annotated?: false, force?: true)
+
+      assert_folders_are_equal(ref_path, xgit_path)
+    end
+
+    test "happy path: annotated tag" do
+      %{xgit_path: ref_path, parent_id: commit_id} = setup_with_valid_parent_commit!()
+
+      assert {_, 0} =
+               System.cmd("git", ["tag", "-a", "-m", "annotation", "sample-tag", commit_id],
+                 cd: ref_path,
+                 env: @env
+               )
+
+      %{xgit_path: xgit_path, xgit_repo: xgit_repo, parent_id: commit_id} =
+        setup_with_valid_parent_commit!()
+
+      assert :ok =
+               Repository.tag(xgit_repo, "sample-tag", commit_id,
+                 annotated?: true,
+                 message: "annotation",
+                 tagger: @valid_pi
+               )
 
       assert_folders_are_equal(ref_path, xgit_path)
     end

--- a/test/xgit/repository/tag_test.exs
+++ b/test/xgit/repository/tag_test.exs
@@ -160,5 +160,42 @@ defmodule Xgit.Repository.TagTest do
                      )
                    end
     end
+
+    test "error: annotated? and message mismatch 1" do
+      {:ok, repo} = InMemory.start_link()
+
+      assert_raise ArgumentError,
+                   ~S(Xgit.Repository.tag/4: annotated?: false can not be specified when message is present),
+                   fn ->
+                     Repository.tag(repo, "abc", "9d252945c1d3c553a30361214db02892d1ea4876",
+                       message: "message",
+                       annotated?: false
+                     )
+                   end
+    end
+
+    test "error: annotated? and message mismatch 2" do
+      {:ok, repo} = InMemory.start_link()
+
+      assert_raise ArgumentError,
+                   ~S(Xgit.Repository.tag/4: annotated?: true can not be specified without message),
+                   fn ->
+                     Repository.tag(repo, "abc", "9d252945c1d3c553a30361214db02892d1ea4876",
+                       annotated?: true
+                     )
+                   end
+    end
+
+    test "error: annotated value is invalid" do
+      {:ok, repo} = InMemory.start_link()
+
+      assert_raise ArgumentError,
+                   ~S(Xgit.Repository.tag/4: annotated? "yes" is invalid),
+                   fn ->
+                     Repository.tag(repo, "abc", "9d252945c1d3c553a30361214db02892d1ea4876",
+                       annotated?: "yes"
+                     )
+                   end
+    end
   end
 end

--- a/test/xgit/repository/tag_test.exs
+++ b/test/xgit/repository/tag_test.exs
@@ -3,6 +3,7 @@ defmodule Xgit.Repository.TagTest do
 
   # alias Xgit.PersonIdent
   alias Xgit.Repository
+  alias Xgit.Repository.InMemory
   alias Xgit.Repository.InvalidRepositoryError
   # alias Xgit.Repository.Plumbing
   # alias Xgit.Repository.Storage
@@ -67,6 +68,97 @@ defmodule Xgit.Repository.TagTest do
                    annotated?: false
                  )
       end
+    end
+
+    test "error: tag name empty" do
+      {:ok, repo} = InMemory.start_link()
+
+      assert_raise ArgumentError,
+                   ~S(Xgit.Repository.tag/4: tag_name "" is invalid),
+                   fn ->
+                     Repository.tag(repo, "", "9d252945c1d3c553a30361214db02892d1ea4876")
+                   end
+    end
+
+    test "error: tag name invalid" do
+      {:ok, repo} = InMemory.start_link()
+
+      assert_raise ArgumentError,
+                   ~S(Xgit.Repository.tag/4: tag_name "abc.lock" is invalid),
+                   fn ->
+                     Repository.tag(repo, "abc.lock", "9d252945c1d3c553a30361214db02892d1ea4876")
+                   end
+    end
+
+    test "error: object ID invalid" do
+      {:ok, repo} = InMemory.start_link()
+
+      assert_raise ArgumentError,
+                   ~S(Xgit.Repository.tag/4: object "9d252945c1d3c553a30361214db02892d1ea487" is invalid),
+                   fn ->
+                     Repository.tag(repo, "abc", "9d252945c1d3c553a30361214db02892d1ea487")
+                     # This object name is 39 hex digits, not 40.
+                   end
+    end
+
+    test "error: force? option value is invalid" do
+      {:ok, repo} = InMemory.start_link()
+
+      assert_raise ArgumentError,
+                   ~S(Xgit.Repository.tag/4: force? "yes" is invalid),
+                   fn ->
+                     Repository.tag(repo, "abc", "9d252945c1d3c553a30361214db02892d1ea4876",
+                       force?: "yes"
+                     )
+                   end
+    end
+
+    test "error: message value is empty" do
+      {:ok, repo} = InMemory.start_link()
+
+      assert_raise ArgumentError,
+                   ~S(Xgit.Repository.tag/4: message must be non-empty if present),
+                   fn ->
+                     Repository.tag(repo, "abc", "9d252945c1d3c553a30361214db02892d1ea4876",
+                       message: ''
+                     )
+                   end
+    end
+
+    test "error: message value is empty (string)" do
+      {:ok, repo} = InMemory.start_link()
+
+      assert_raise ArgumentError,
+                   ~S(Xgit.Repository.tag/4: message must be non-empty if present),
+                   fn ->
+                     Repository.tag(repo, "abc", "9d252945c1d3c553a30361214db02892d1ea4876",
+                       message: ""
+                     )
+                   end
+    end
+
+    test "error: message value is empty (charlist)" do
+      {:ok, repo} = InMemory.start_link()
+
+      assert_raise ArgumentError,
+                   ~S(Xgit.Repository.tag/4: message must be non-empty if present),
+                   fn ->
+                     Repository.tag(repo, "abc", "9d252945c1d3c553a30361214db02892d1ea4876",
+                       message: ''
+                     )
+                   end
+    end
+
+    test "error: message value is invalid" do
+      {:ok, repo} = InMemory.start_link()
+
+      assert_raise ArgumentError,
+                   ~S(Xgit.Repository.tag/4: message :message is invalid),
+                   fn ->
+                     Repository.tag(repo, "abc", "9d252945c1d3c553a30361214db02892d1ea4876",
+                       message: :message
+                     )
+                   end
     end
   end
 end

--- a/test/xgit/repository/tag_test.exs
+++ b/test/xgit/repository/tag_test.exs
@@ -1,0 +1,76 @@
+defmodule Xgit.Repository.TagTest do
+  use ExUnit.Case, async: true
+
+  # alias Xgit.PersonIdent
+  alias Xgit.Repository
+  alias Xgit.Repository.InvalidRepositoryError
+  # alias Xgit.Repository.Plumbing
+  # alias Xgit.Repository.Storage
+  alias Xgit.Test.OnDiskRepoTestCase
+
+  import FolderDiff
+
+  import Xgit.Test.OnDiskRepoTestCase,
+    only: [setup_with_valid_parent_commit!: 1]
+
+  describe "tag/4" do
+    # @valid_pi %PersonIdent{
+    #   name: "A. U. Thor",
+    #   email: "author@example.com",
+    #   when: 1_142_878_449_000,
+    #   tz_offset: 150
+    # }
+
+    @env OnDiskRepoTestCase.sample_commit_env()
+
+    test "happy path: lightweight tag" do
+      %{xgit_path: ref_path, parent_id: commit_id} =
+        setup_with_valid_parent_commit!()
+
+      assert {_, 0} =
+               System.cmd("git", ["tag", "sample-tag", commit_id],
+                 cd: ref_path,
+                 env: @env
+               )
+
+      %{xgit_path: xgit_path, xgit_repo: xgit_repo, parent_id: commit_id} =
+        setup_with_valid_parent_commit!()
+
+      assert :ok = Repository.tag(xgit_repo, "sample-tag", commit_id, annotated?: false)
+
+      assert_folders_are_equal(ref_path, xgit_path)
+    end
+
+    test "happy path: lightweight tag as default when no message" do
+      %{xgit_path: ref_path, parent_id: commit_id} =
+        setup_with_valid_parent_commit!()
+
+      assert {_, 0} =
+               System.cmd("git", ["tag", "sample-tag", commit_id],
+                 cd: ref_path,
+                 env: @env
+               )
+
+      %{xgit_path: xgit_path, xgit_repo: xgit_repo, parent_id: commit_id} =
+        setup_with_valid_parent_commit!()
+
+      assert :ok = Repository.tag(xgit_repo, "sample-tag", commit_id)
+
+      assert_folders_are_equal(ref_path, xgit_path)
+    end
+
+    test "error: invalid repo" do
+      {:ok, not_repo} = GenServer.start_link(NotValid, nil)
+
+      assert_raise InvalidRepositoryError, fn ->
+        assert :ok =
+                 Repository.tag(
+                   not_repo,
+                   "sample-tag",
+                   "9d252945c1d3c553a30361214db02892d1ea4876",
+                   annotated?: false
+                 )
+      end
+    end
+  end
+end

--- a/test/xgit/repository/tag_test.exs
+++ b/test/xgit/repository/tag_test.exs
@@ -56,6 +56,59 @@ defmodule Xgit.Repository.TagTest do
       assert_folders_are_equal(ref_path, xgit_path)
     end
 
+    test "happy path: won't rewrite existing lightweight tag" do
+      %{xgit_path: ref_path, parent_id: commit_id} = setup_with_valid_parent_commit!()
+
+      assert {_, 0} =
+               System.cmd("git", ["tag", "sample-tag", commit_id],
+                 cd: ref_path,
+                 env: @env
+               )
+
+      assert {_, 0} =
+               System.cmd("git", ["commit", "--allow-empty", "--message", "another commit"],
+                 cd: ref_path,
+                 env: @env
+               )
+
+      assert {commit2_id_str, 0} =
+               System.cmd("git", ["log", "-1", "--pretty=format:%H"], cd: ref_path)
+
+      commit2_id = String.trim(commit2_id_str)
+
+      assert {_, 128} =
+               System.cmd("git", ["tag", "sample-tag", commit2_id],
+                 cd: ref_path,
+                 env: @env,
+                 stderr_to_stdout: true
+               )
+
+      %{xgit_path: xgit_path, xgit_repo: xgit_repo, parent_id: commit_id} =
+        setup_with_valid_parent_commit!()
+
+      assert {_, 0} =
+               System.cmd("git", ["tag", "sample-tag", commit_id],
+                 cd: xgit_path,
+                 env: @env
+               )
+
+      assert {_, 0} =
+               System.cmd("git", ["commit", "--allow-empty", "--message", "another commit"],
+                 cd: xgit_path,
+                 env: @env
+               )
+
+      assert {commit2_id_str, 0} =
+               System.cmd("git", ["log", "-1", "--pretty=format:%H"], cd: xgit_path)
+
+      commit2_id = String.trim(commit2_id_str)
+
+      assert {:error, :old_target_not_matched} =
+               Repository.tag(xgit_repo, "sample-tag", commit2_id, annotated?: false)
+
+      assert_folders_are_equal(ref_path, xgit_path)
+    end
+
     test "error: invalid repo" do
       {:ok, not_repo} = GenServer.start_link(NotValid, nil)
 

--- a/test/xgit/repository/tag_test.exs
+++ b/test/xgit/repository/tag_test.exs
@@ -24,8 +24,7 @@ defmodule Xgit.Repository.TagTest do
     @env OnDiskRepoTestCase.sample_commit_env()
 
     test "happy path: lightweight tag" do
-      %{xgit_path: ref_path, parent_id: commit_id} =
-        setup_with_valid_parent_commit!()
+      %{xgit_path: ref_path, parent_id: commit_id} = setup_with_valid_parent_commit!()
 
       assert {_, 0} =
                System.cmd("git", ["tag", "sample-tag", commit_id],
@@ -42,8 +41,7 @@ defmodule Xgit.Repository.TagTest do
     end
 
     test "happy path: lightweight tag as default when no message" do
-      %{xgit_path: ref_path, parent_id: commit_id} =
-        setup_with_valid_parent_commit!()
+      %{xgit_path: ref_path, parent_id: commit_id} = setup_with_valid_parent_commit!()
 
       assert {_, 0} =
                System.cmd("git", ["tag", "sample-tag", commit_id],

--- a/test/xgit/repository/tag_test.exs
+++ b/test/xgit/repository/tag_test.exs
@@ -9,9 +9,7 @@ defmodule Xgit.Repository.TagTest do
   alias Xgit.Test.OnDiskRepoTestCase
 
   import FolderDiff
-
-  import Xgit.Test.OnDiskRepoTestCase,
-    only: [setup_with_valid_parent_commit!: 1]
+  import Xgit.Test.OnDiskRepoTestCase, only: [setup_with_valid_parent_commit!: 0]
 
   describe "tag/4" do
     # @valid_pi %PersonIdent{


### PR DESCRIPTION
## Changes in This Pull Request
Adds `Xgit.Repository.tag/4`, which is an analogue to the creation case of [`git tag`](https://git-scm.com/docs/git-tag).

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] There is test coverage for all changes.
- [x] All cases where a literal value is returned use the `cover` macro to force code coverage.
- ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
