### PR TITLE
Transfer responsibility for enforcing tag target type to Xgit.Repository.Plumbing.

### DIFF
--- a/lib/xgit/repository/in_memory.ex
+++ b/lib/xgit/repository/in_memory.ex
@@ -106,12 +106,12 @@ defmodule Xgit.Repository.InMemory do
   defp verify_target(_state, "ref: " <> _), do: cover(:ok)
 
   defp verify_target(state, target) do
-    with {:object, %Object{} = object} <- {:object, get_object_imp(state, target)},
-         {:type, %{type: :commit}} <- {:type, object} do
-      :ok
+    object = get_object_imp(state, target)
+
+    if object == nil do
+      cover {:error, :target_not_found}
     else
-      {:object, nil} -> cover {:error, :target_not_found}
-      {:type, _} -> cover {:error, :target_not_commit}
+      cover :ok
     end
   end
 

--- a/lib/xgit/repository/on_disk.ex
+++ b/lib/xgit/repository/on_disk.ex
@@ -444,12 +444,12 @@ defmodule Xgit.Repository.OnDisk do
   defp verify_target(_state, "ref: " <> _), do: cover(:ok)
 
   defp verify_target(state, target) do
-    with {:object, %Object{} = object} <- {:object, get_object_imp(state, target)},
-         {:type, %{type: :commit}} <- {:type, object} do
-      :ok
+    object = get_object_imp(state, target)
+
+    if object == {:error, :not_found} do
+      cover {:error, :target_not_found}
     else
-      {:object, {:error, :not_found}} -> cover {:error, :target_not_found}
-      {:type, _} -> cover {:error, :target_not_commit}
+      cover :ok
     end
   end
 

--- a/lib/xgit/repository/storage.ex
+++ b/lib/xgit/repository/storage.ex
@@ -313,7 +313,6 @@ defmodule Xgit.Repository.Storage do
           :invalid_ref
           | :cant_create_file
           | :target_not_found
-          | :target_not_commit
           | :old_target_not_matched
 
   @doc ~S"""
@@ -344,8 +343,6 @@ defmodule Xgit.Repository.Storage do
   `{:error, :cant_create_file}` if unable to create the storage for the reference.
 
   `{:error, :target_not_found}` if the target object does not exist in the repository.
-
-  `{:error, :target_not_commit}` if the target object is not of type `commit`.
 
   `{:error, :old_target_not_matched}` if `old_target` was specified and the target ref points
   to a different object ID.
@@ -395,9 +392,6 @@ defmodule Xgit.Repository.Storage do
 
   Should return `{:error, :target_not_found}` if the target object does not
   exist in the repository.
-
-  Should return `{:error, :target_not_commit}` if the target object is not
-  of type `commit`.
 
   Should return `{:error, :old_target_not_matched}` if `old_target` was specified and the
   target ref points to a different object ID.

--- a/lib/xgit/repository/test/ref_test.ex
+++ b/lib/xgit/repository/test/ref_test.ex
@@ -79,7 +79,7 @@ defmodule Xgit.Repository.Test.RefTest do
         object = %Object{type: :blob, content: @test_content, size: 13, id: @test_content_id}
         :ok = Storage.put_loose_object(repo, object)
 
-        assert {:error, :target_not_commit} =
+        assert :ok =
                  Storage.put_ref(repo, %Ref{
                    name: "refs/heads/master",
                    target: @test_content_id


### PR DESCRIPTION
## Changes in This Pull Request
Previously, `Xgit.Repository.Storage.put_ref/3` verified that the target object was of type `commit`. This caused a problem with the upcoming implementation of `Xgit.Repository.tag/4`, which needed to be able to write a `tag` object and have that pointed to by the ref.

This PR moves that enforcement to `Xgit.Repository.Plumbing.update_ref/4`.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] There is test coverage for all changes.
- [x] All cases where a literal value is returned use the `cover` macro to force code coverage.
- ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
