### PR TITLE
Adapt some of git's tests for `git init`.

### DIFF
--- a/test/xgit/repository/on_disk/create_test.exs
+++ b/test/xgit/repository/on_disk/create_test.exs
@@ -1,20 +1,87 @@
 defmodule Xgit.Repository.OnDisk.CreateTest do
+  use Bitwise
   use ExUnit.Case, async: true
 
   alias Xgit.Repository.OnDisk
   alias Xgit.Test.OnDiskRepoTestCase
+  alias Xgit.Test.TempDirTestCase
 
   import FolderDiff
 
   describe "create/1" do
     test "happy path matches command-line git" do
       %{xgit_path: ref} = OnDiskRepoTestCase.repo!()
-      %{xgit_path: xgit_root} = OnDiskRepoTestCase.repo!()
+      %{tmp_dir: xgit_root} = TempDirTestCase.tmp_dir!()
 
       xgit = Path.join(xgit_root, "repo")
 
       assert :ok = OnDisk.create(xgit)
       assert_folders_are_equal(ref, xgit)
+    end
+
+    test ".git/objects should be empty after git init in an empty repo" do
+      # Adapted from git t0000-basic.sh
+      %{tmp_dir: xgit_root} = TempDirTestCase.tmp_dir!()
+
+      xgit = Path.join(xgit_root, "repo")
+      assert :ok = OnDisk.create(xgit)
+
+      assert {"", 0} = System.cmd("find", [".git/objects", "-type", "f"], cd: xgit)
+    end
+
+    test ".git/objects should have 3 subdirectories" do
+      # Adapted from git t0000-basic.sh
+
+      %{tmp_dir: xgit_root} = TempDirTestCase.tmp_dir!()
+
+      xgit = Path.join(xgit_root, "repo")
+      assert :ok = OnDisk.create(xgit)
+
+      assert {dirs_str, 0} = System.cmd("find", [".git/objects", "-type", "d"], cd: xgit)
+
+      dirs =
+        dirs_str
+        |> String.split("\n", trim: true)
+        |> Enum.sort()
+
+      assert dirs == [".git/objects", ".git/objects/info", ".git/objects/pack"]
+    end
+
+    defp check_config(path) do
+      assert File.dir?(path)
+      assert File.dir?(Path.join(path, ".git"))
+      assert File.regular?(Path.join(path, ".git/config"))
+      assert File.dir?(Path.join(path, ".git/refs"))
+
+      refute executable?(Path.join(path, ".git/config"))
+
+      # bare=$(cd "$1" && git config --bool core.bare)
+      # worktree=$(cd "$1" && git config core.worktree) ||
+      # worktree=unset
+
+      # test "$bare" = "$2" && test "$worktree" = "$3" || {
+      #   echo "expected bare=$2 worktree=$3"
+      #   echo "     got bare=$bare worktree=$worktree"
+      #   return 1
+      # }
+    end
+
+    defp executable?(path) do
+      case File.lstat(path) do
+        {:ok, %File.Stat{mode: mode}} -> (mode &&& 0o100) == 0o100
+        _ -> false
+      end
+    end
+
+    test "plain" do
+      # Adapted from git t0001-init.sh
+
+      %{tmp_dir: xgit_root} = TempDirTestCase.tmp_dir!()
+
+      xgit = Path.join(xgit_root, "repo")
+      assert :ok = OnDisk.create(xgit)
+
+      check_config(xgit)
     end
 
     test "error: no work_dir" do


### PR DESCRIPTION
## Changes in This Pull Request
Review some of git's test suite. Mimic a few tests for the subset of `git init` that we implement in `Xgit.Repository.OnDisk.create/1`.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- ~All applicable changes have been documented.~ _n/a_
- ~There is test coverage for all changes.~ _n/a_
- ~All cases where a literal value is returned use the `cover` macro to force code coverage.~ _n/a_
- ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
