### PR TITLE
Implement Xgit.ConfigEntry.

### DIFF
--- a/lib/xgit/config_entry.ex
+++ b/lib/xgit/config_entry.ex
@@ -1,0 +1,105 @@
+defmodule Xgit.ConfigEntry do
+  @moduledoc ~S"""
+  Represents one entry in a git configuration dictionary.
+
+  This is also commonly referred to as a "config _line_" because it typically
+  occupies one line in a typical git configuration file.
+
+  The semantically-important portion of a configuration file (i.e. everything
+  except comments and whitespace) could be represented by a list of `ConfigEntry`
+  structs.
+  """
+
+  import Xgit.Util.ForceCoverage
+
+  @typedoc ~S"""
+  Represents an entry in a git config file.
+
+  ## Struct Members
+
+  * `section`: (`String`) section name for the entry
+  * `subsection`: (`String` or `nil`) subsection name
+  * `name`: (`String`) key name
+  * `value`: (`String`, `nil`, or `:remove`) value
+    * `nil` if the name is present without an `=`
+    * `:remove_all` can be used as an instruction in some APIs to remove any corresponding entries
+  """
+  @type t :: %__MODULE__{
+          section: String.t(),
+          subsection: String.t() | nil,
+          name: String.t(),
+          value: String.t() | nil
+        }
+
+  @enforce_keys [:section, :subsection, :name, :value]
+  defstruct [:section, :name, subsection: nil, value: nil]
+
+  @doc ~S"""
+  Returns `true` if passed a valid config entry.
+  """
+  @spec valid?(value :: any) :: boolean
+  def valid?(%__MODULE{} = entry) do
+    valid_section?(entry.section) &&
+      valid_subsection?(entry.subsection) &&
+      valid_name?(entry.name) &&
+      valid_value?(entry.value)
+  end
+
+  def valid?(_), do: cover(false)
+
+  @doc ~S"""
+  Returns `true` if passed a valid config section name.
+
+  Only alphanumeric characters, `-`, and `.` are allowed in section names.
+  """
+  @spec valid_section?(section :: any) :: boolean
+  def valid_section?(section) when is_binary(section) do
+    String.match?(section, ~r/^[-A-Za-z0-9.]+$/)
+  end
+
+  def valid_section?(nil), do: cover(true)
+  def valid_section?(_), do: cover(false)
+
+  @doc ~S"""
+  Returns `true` if passed a valid config subsection name.
+  """
+  @spec valid_subsection?(subsection :: any) :: boolean
+  def valid_subsection?(subsection) when is_binary(subsection) do
+    if String.match?(subsection, ~r/[\0\n]/) do
+      cover false
+    else
+      cover true
+    end
+  end
+
+  def valid_subsection?(nil), do: cover(true)
+  def valid_subsection?(_), do: cover(false)
+
+  @doc ~S"""
+  Returns `true` if passed a valid config entry name.
+  """
+  @spec valid_name?(name :: any) :: boolean
+  def valid_name?(name) when is_binary(name) do
+    String.match?(name, ~r/^[A-Za-z][-A-Za-z0-9]*$/)
+  end
+
+  def valid_name?(_), do: cover(false)
+
+  @doc ~S"""
+  Returns `true` if passed a valid config value string.
+
+  Important: At this level, we do not accept other data types.
+  """
+  @spec valid_value?(value :: any) :: boolean
+  def valid_value?(value) when is_binary(value) do
+    if String.match?(value, ~r/\0/) do
+      cover false
+    else
+      cover true
+    end
+  end
+
+  def valid_value?(nil), do: cover(true)
+  def valid_value?(:remove_all), do: cover(true)
+  def valid_value?(_), do: cover(false)
+end

--- a/lib/xgit/config_entry.ex
+++ b/lib/xgit/config_entry.ex
@@ -38,7 +38,7 @@ defmodule Xgit.ConfigEntry do
   Returns `true` if passed a valid config entry.
   """
   @spec valid?(value :: any) :: boolean
-  def valid?(%__MODULE{} = entry) do
+  def valid?(%__MODULE__{} = entry) do
     valid_section?(entry.section) &&
       valid_subsection?(entry.subsection) &&
       valid_name?(entry.name) &&

--- a/lib/xgit/config_entry.ex
+++ b/lib/xgit/config_entry.ex
@@ -20,7 +20,7 @@ defmodule Xgit.ConfigEntry do
   * `section`: (`String`) section name for the entry
   * `subsection`: (`String` or `nil`) subsection name
   * `name`: (`String`) key name
-  * `value`: (`String`, `nil`, or `:remove`) value
+  * `value`: (`String`, `nil`, or `:remove_all`) value
     * `nil` if the name is present without an `=`
     * `:remove_all` can be used as an instruction in some APIs to remove any corresponding entries
   """
@@ -28,7 +28,7 @@ defmodule Xgit.ConfigEntry do
           section: String.t(),
           subsection: String.t() | nil,
           name: String.t(),
-          value: String.t() | nil
+          value: String.t() | :remove_all | nil
         }
 
   @enforce_keys [:section, :subsection, :name, :value]
@@ -57,7 +57,6 @@ defmodule Xgit.ConfigEntry do
     String.match?(section, ~r/^[-A-Za-z0-9.]+$/)
   end
 
-  def valid_section?(nil), do: cover(true)
   def valid_section?(_), do: cover(false)
 
   @doc ~S"""

--- a/mix.exs
+++ b/mix.exs
@@ -64,6 +64,7 @@ defmodule Xgit.MixProject do
         ],
         "Core Data Model": [
           "Xgit.Commit",
+          "Xgit.ConfigEntry",
           "Xgit.ContentSource",
           "Xgit.DirCache",
           "Xgit.DirCache.Entry",

--- a/test/xgit/config_entry_test.exs
+++ b/test/xgit/config_entry_test.exs
@@ -3,8 +3,8 @@ defmodule Xgit.ConfigEntryTest do
 
   alias Xgit.ConfigEntry
 
-  @valid_sections ["test", "Test", "test-24", "test-2.3", nil]
-  @invalid_sections ["", 'test', "", "test 24", "test:24", "test/more-test", 42, :test]
+  @valid_sections ["test", "Test", "test-24", "test-2.3"]
+  @invalid_sections ["", 'test', "", "test 24", "test:24", "test/more-test", 42, :test, nil]
 
   @valid_subsections ["xgit", "", "xgit and more xgit", "test:24", "test/more-test", nil]
   @invalid_subsections ["xg\nit", "xg\0it", 'xgit', 42, :test]
@@ -12,7 +12,7 @@ defmodule Xgit.ConfigEntryTest do
   @valid_names ["random", "Random", "random9", "random-9"]
   @invalid_names ["", "9random", "random.24", "random:24", 42, nil, :test]
 
-  @valid_values ["whatever", "", nil]
+  @valid_values ["whatever", "", :remove_all, nil]
   @invalid_values ["what\0ever", 'whatever', 42, true, false, :test]
 
   @valid_entry %ConfigEntry{

--- a/test/xgit/config_entry_test.exs
+++ b/test/xgit/config_entry_test.exs
@@ -43,6 +43,17 @@ defmodule Xgit.ConfigEntryTest do
       end
     end
 
+    test "not a struct" do
+      refute ConfigEntry.valid?(%{
+               section: "test",
+               subsection: "xgit",
+               name: "random",
+               value: "whatever"
+             })
+
+      refute ConfigEntry.valid?("[test] random=whatever")
+    end
+
     test "invalid section" do
       for section <- @invalid_sections do
         entry = %{@valid_entry | section: section}

--- a/test/xgit/config_entry_test.exs
+++ b/test/xgit/config_entry_test.exs
@@ -1,0 +1,146 @@
+defmodule Xgit.ConfigEntryTest do
+  use ExUnit.Case, async: true
+
+  alias Xgit.ConfigEntry
+
+  @valid_sections ["test", "Test", "test-24", "test-2.3", nil]
+  @invalid_sections ["", 'test', "", "test 24", "test:24", "test/more-test", 42, :test]
+
+  @valid_subsections ["xgit", "", "xgit and more xgit", "test:24", "test/more-test", nil]
+  @invalid_subsections ["xg\nit", "xg\0it", 'xgit', 42, :test]
+
+  @valid_names ["random", "Random", "random9", "random-9"]
+  @invalid_names ["", "9random", "random.24", "random:24", 42, nil, :test]
+
+  @valid_values ["whatever", "", nil]
+  @invalid_values ["what\0ever", 'whatever', 42, true, false, :test]
+
+  @valid_entry %ConfigEntry{
+    section: "test",
+    subsection: "xgit",
+    name: "random",
+    value: "whatever"
+  }
+
+  describe "valid?/1" do
+    test "valid cases" do
+      for section <- @valid_sections do
+        for subsection <- @valid_subsections do
+          for name <- @valid_names do
+            for value <- @valid_values do
+              entry = %ConfigEntry{
+                section: section,
+                subsection: subsection,
+                name: name,
+                value: value
+              }
+
+              assert ConfigEntry.valid?(entry),
+                     "improperly rejected valid case #{inspect(entry, pretty: true)}"
+            end
+          end
+        end
+      end
+    end
+
+    test "invalid section" do
+      for section <- @invalid_sections do
+        entry = %{@valid_entry | section: section}
+
+        refute ConfigEntry.valid?(entry),
+               "improperly accepted invalid case #{inspect(entry, pretty: true)}"
+      end
+    end
+
+    test "invalid subsection" do
+      for subsection <- @invalid_subsections do
+        entry = %{@valid_entry | subsection: subsection}
+
+        refute ConfigEntry.valid?(entry),
+               "improperly accepted invalid case #{inspect(entry, pretty: true)}"
+      end
+    end
+
+    test "invalid name" do
+      for name <- @invalid_names do
+        entry = %{@valid_entry | name: name}
+
+        refute ConfigEntry.valid?(entry),
+               "improperly accepted invalid case #{inspect(entry, pretty: true)}"
+      end
+    end
+
+    test "invalid value" do
+      for value <- @invalid_values do
+        entry = %{@valid_entry | value: value}
+
+        refute ConfigEntry.valid?(entry),
+               "improperly accepted invalid case #{inspect(entry, pretty: true)}"
+      end
+    end
+  end
+
+  describe "valid_section?/1" do
+    test "valid section names" do
+      for section <- @valid_sections do
+        assert ConfigEntry.valid_section?(section),
+               "improperly rejected valid case #{inspect(section)}"
+      end
+    end
+
+    test "invalid section names" do
+      for section <- @invalid_sections do
+        refute ConfigEntry.valid_section?(section),
+               "improperly accepted invalid case #{inspect(section)}"
+      end
+    end
+  end
+
+  describe "valid_subsection?/1" do
+    test "valid subsection names" do
+      for subsection <- @valid_subsections do
+        assert ConfigEntry.valid_subsection?(subsection),
+               "improperly rejected valid case #{inspect(subsection)}"
+      end
+    end
+
+    test "invalid subsection names" do
+      for subsection <- @invalid_subsections do
+        refute ConfigEntry.valid_subsection?(subsection),
+               "improperly accepted invalid case #{inspect(subsection)}"
+      end
+    end
+  end
+
+  describe "valid_name?/1" do
+    test "valid names" do
+      for name <- @valid_names do
+        assert ConfigEntry.valid_name?(name),
+               "improperly rejected valid case #{inspect(name)}"
+      end
+    end
+
+    test "invalid names" do
+      for name <- @invalid_names do
+        refute ConfigEntry.valid_name?(name),
+               "improperly accepted invalid case #{inspect(name)}"
+      end
+    end
+  end
+
+  describe "valid_value?/1" do
+    test "valid values" do
+      for value <- @valid_values do
+        assert ConfigEntry.valid_value?(value),
+               "improperly rejected valid case #{inspect(value)}"
+      end
+    end
+
+    test "invalid values" do
+      for value <- @invalid_values do
+        refute ConfigEntry.valid_value?(value),
+               "improperly accepted invalid case #{inspect(value)}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Changes in This Pull Request
This struct describes a single line in a config file or similar storage mechanism.


## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] There is test coverage for all changes.
- [x] All cases where a literal value is returned use the `cover` macro to force code coverage.
- ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
