### PR TITLE
Implement Xgit.Util.ConfigFile.

### DIFF
--- a/lib/xgit/util/config_file.ex
+++ b/lib/xgit/util/config_file.ex
@@ -145,7 +145,7 @@ defmodule Xgit.Util.ConfigFile do
       [] -> cover :ok
       [?# | _] -> cover :ok
       [?; | _] -> cover :ok
-      _ -> raise "Illegal variable declaration: #{line}"
+      _ -> raise ArgumentError, "Illegal variable declaration: #{line}"
     end
 
     {section, subsection, maybe_config_entry(section, subsection, var_name, value)}
@@ -165,7 +165,7 @@ defmodule Xgit.Util.ConfigFile do
     remainder =
       case remainder do
         [?] | x] -> Enum.drop_while(x, &whitespace?/1)
-        _ -> raise "Illegal section header #{line}"
+        _ -> raise ArgumentError, "Illegal section header #{line}"
       end
 
     {section |> to_string() |> String.downcase(), subsection, remainder}
@@ -226,12 +226,12 @@ defmodule Xgit.Util.ConfigFile do
     {Enum.reverse(quoted_string), remainder}
   end
 
-  defp read_quoted_string(_acc, [?\\ | [?\n | _remainder]]) do
-    raise "Illegal quoted string: Can not span a new line"
+  defp read_quoted_string(_acc, [?\n | _remainder]) do
+    raise ArgumentError, "Illegal quoted string: Can not span a new line"
   end
 
   defp read_quoted_string(_acc, []) do
-    raise "Illegal quoted string: Missing close quote"
+    raise ArgumentError, "Illegal quoted string: Missing close quote"
   end
 
   defp read_quoted_string(acc, [?\\ | [c | remainder]]),

--- a/lib/xgit/util/config_file.ex
+++ b/lib/xgit/util/config_file.ex
@@ -163,7 +163,7 @@ defmodule Xgit.Util.ConfigFile do
         _ -> raise "Illegal section header #{line}"
       end
 
-    {to_string(section), nil, remainder}
+    {section |> to_string() |> String.downcase(), nil, remainder}
   end
 
   defp read_optional_section_header(remainder, section, subsection),

--- a/lib/xgit/util/config_file.ex
+++ b/lib/xgit/util/config_file.ex
@@ -139,9 +139,14 @@ defmodule Xgit.Util.ConfigFile do
     {section, subsection, remainder} =
       read_optional_section_header(remainder, section, subsection)
 
-    {var_name, value, _remainder} = read_optional_variable(remainder)
+    {var_name, value, remainder} = read_optional_variable(remainder)
 
-    # At this point, it must be whitespace + EOL or a comment.
+    case Enum.drop_while(remainder, &whitespace?/1) do
+      [] -> cover :ok
+      [?# | _] -> cover :ok
+      [?; | _] -> cover :ok
+      _ -> raise "Illegal variable declaration: #{line}"
+    end
 
     {section, subsection, maybe_config_entry(section, subsection, var_name, value)}
   end
@@ -190,7 +195,7 @@ defmodule Xgit.Util.ConfigFile do
       cover {nil, nil, remainder}
     else
       {value, remainder} = read_optional_value(remainder)
-      cover {to_string(var_name), value, remainder}
+      cover {var_name |> to_string() |> String.downcase(), value, remainder}
     end
   end
 

--- a/lib/xgit/util/config_file.ex
+++ b/lib/xgit/util/config_file.ex
@@ -69,8 +69,6 @@ defmodule Xgit.Util.ConfigFile do
 
   `{:ok, [entries]}` where `entries` is a list of `Xgit.ConfigEntry` structs that match the
   search parameters.
-
-  `{:error, TBD}` if unable.
   """
   @spec get_entries(config_file :: t,
           section: String.t(),
@@ -95,11 +93,7 @@ defmodule Xgit.Util.ConfigFile do
 
   ## --- Parsing ---
 
-  @doc false
-  # Public only for testing purposes. Read config file at path and return
-  # a list of ConfigFile.Line structs representing that file.
-  @spec parse_config_at_path(path :: Path.t()) :: [%__MODULE__.Line{}]
-  def parse_config_at_path(path) do
+  defp parse_config_at_path(path) do
     path
     |> File.stream!()
     |> Enum.to_list()

--- a/lib/xgit/util/config_file.ex
+++ b/lib/xgit/util/config_file.ex
@@ -1,0 +1,240 @@
+defmodule Xgit.Util.ConfigFile do
+  @moduledoc false
+  # This GenServer monitors and potentially updates the contents
+  # of an on-disk git config file. It is primarily intended to be
+  # used by Xgit.Repository.OnDisk, but may be of use elsewhere.
+
+  use GenServer
+
+  require Logger
+
+  alias Xgit.ConfigEntry
+  alias Xgit.Util.ObservedFile
+  alias Xgit.Util.ParseCharlist
+
+  import Xgit.Util.ForceCoverage
+
+  @typedoc ~S"""
+  Process ID for an `Xgit.ConfigFile` process.
+  """
+  @type t :: pid
+
+  defmodule Line do
+    @moduledoc false
+    # Wraps the public Xgit.ConfigEntry with some additional infrastructure
+    # that lets us reconstruct the exact contents of the file.
+
+    defstruct [:entry, :original, :section, :subsection]
+  end
+
+  @doc ~S"""
+  Start a `ConfigFile` for a config file at the given path.
+
+  The path (including parent directory) needs to exist, but there
+  need not be a file at this path.
+  """
+  @spec start_link(path :: Path.t()) :: GenServer.on_start()
+  def start_link(path) when is_binary(path) do
+    unless File.dir?(Path.dirname(path)) do
+      raise ArgumentError,
+            "Xgit.Util.ConfigFile.start_link/1: Parent of path #{path} must be an existing directory"
+    end
+
+    GenServer.start_link(__MODULE__, path)
+  end
+
+  @impl true
+  def init(path) when is_binary(path),
+    do: {:ok, ObservedFile.initial_state_for_path(path, &parse_config_at_path/1, &empty_config/0)}
+
+  @typedoc ~S"""
+  Error codes that can be returned by `get_entries/2`.
+  """
+  @type get_entries_reason :: File.posix()
+
+  @doc ~S"""
+  Return any configuration entries that match the requested search.
+
+  Entries will be returned in the order in which they appeared in the underlying file.
+
+  ## Options
+
+  * `section:` (`String`) if provided, only returns entries in the named section
+  * `subsection:` (`String`) if provided, only returns entries in the named subsection
+  * `name:` (`String`) if provided, only returns entries with the given variable name
+
+  If no options are provided, returns all entries.
+
+  ## Return Values
+
+  `{:ok, [entries]}` where `entries` is a list of `Xgit.ConfigEntry` structs that match the
+  search parameters.
+
+  `{:error, TBD}` if unable.
+  """
+  @spec get_entries(config_file :: t,
+          section: String.t(),
+          subsection: String.t(),
+          name: String.t()
+        ) ::
+          {:ok, entries :: [Xgit.ConfigEntry.t()]} | {:error, reason :: get_entries_reason}
+  def get_entries(config_file, opts \\ []) when is_pid(config_file) and is_list(opts),
+    do: GenServer.call(config_file, {:get_entries, opts})
+
+  defp handle_get_entries(%ObservedFile{} = of, [] = _opts) do
+    %{parsed_state: lines} =
+      of = ObservedFile.update_state_if_maybe_dirty(of, &parse_config_at_path/1, &empty_config/0)
+
+    entries =
+      lines
+      |> Enum.filter(&(&1.entry != nil))
+      |> Enum.map(& &1.entry)
+
+    {:reply, {:ok, entries}, of}
+  end
+
+  ## --- Parsing ---
+
+  @doc false
+  # Public only for testing purposes. Read config file at path and return
+  # a list of ConfigFile.Line structs representing that file.
+  @spec parse_config_at_path(path :: Path.t()) :: [%__MODULE__.Line{}]
+  def parse_config_at_path(path) do
+    path
+    |> File.stream!()
+    |> Enum.to_list()
+    |> Enum.map(&String.replace_suffix(&1, "\n", ""))
+    |> Enum.reduce([], &join_backslashed_lines/2)
+    |> Enum.reverse()
+    |> Enum.reduce({[], nil, nil}, &text_to_line/2)
+    |> elem(0)
+    |> Enum.reverse()
+  end
+
+  defp join_backslashed_lines(line, [most_recent_line | tail] = reversed_lines) do
+    if String.ends_with?(most_recent_line, "\\") and
+         not String.ends_with?(most_recent_line, "\\\\") do
+      most_recent_line = String.replace_suffix(most_recent_line, "\\", "")
+      cover ["#{most_recent_line}\n#{line}" | tail]
+    else
+      cover [line | reversed_lines]
+    end
+  end
+
+  defp join_backslashed_lines(line, reversed_lines), do: cover([line | reversed_lines])
+
+  defp text_to_line(line, {reversed_lines, section, subsection}) do
+    {section, subsection, entry} =
+      charlist_to_entry(String.to_charlist(line), section, subsection)
+
+    {[
+       %__MODULE__.Line{entry: entry, original: line, section: section, subsection: subsection}
+       | reversed_lines
+     ], section, subsection}
+  end
+
+  defp charlist_to_entry(line, section, subsection) do
+    remainder = Enum.drop_while(line, &whitespace?/1)
+
+    {section, subsection, remainder} =
+      read_optional_section_header(remainder, section, subsection)
+
+    {var_name, value, _remainder} = read_optional_variable(remainder)
+
+    # At this point, it must be whitespace + EOL or a comment.
+
+    {section, subsection, maybe_config_entry(section, subsection, var_name, value)}
+  end
+
+  defp whitespace?(?\s), do: cover(true)
+  defp whitespace?(?\t), do: cover(true)
+  defp whitespace?(_), do: cover(false)
+
+  defp read_optional_section_header([?[ | remainder] = line, _section, _subsection) do
+    remainder = Enum.drop_while(remainder, &whitespace?/1)
+    {section, remainder} = Enum.split_while(remainder, &section_name_char?/1)
+    remainder = Enum.drop_while(remainder, &whitespace?/1)
+    # {subsection, remainder} = read_optional_subsection_header(remainder) - ignore for now
+    remainder = Enum.drop_while(remainder, &whitespace?/1)
+
+    remainder =
+      case remainder do
+        [?] | x] -> Enum.drop_while(x, &whitespace?/1)
+        _ -> raise "Illegal section header #{line}"
+      end
+
+    {to_string(section), nil, remainder}
+  end
+
+  defp read_optional_section_header(remainder, section, subsection),
+    do: cover({section, subsection, remainder})
+
+  defp section_name_char?(c) when c >= ?A and c <= ?Z, do: cover(true)
+  defp section_name_char?(c) when c >= ?a and c <= ?z, do: cover(true)
+  defp section_name_char?(c) when c >= ?0 and c <= ?9, do: cover(true)
+  defp section_name_char?(?-), do: cover(true)
+  defp section_name_char?(?.), do: cover(true)
+  defp section_name_char?(_), do: cover(false)
+
+  defp read_optional_variable(remainder) do
+    {var_name, remainder} = Enum.split_while(remainder, &var_name_char?/1)
+
+    if Enum.empty?(var_name) do
+      cover {nil, nil, remainder}
+    else
+      {value, remainder} = read_optional_value(remainder)
+      cover {to_string(var_name), value, remainder}
+    end
+  end
+
+  defp var_name_char?(c) when c >= ?A and c <= ?Z, do: cover(true)
+  defp var_name_char?(c) when c >= ?a and c <= ?z, do: cover(true)
+  defp var_name_char?(c) when c >= ?0 and c <= ?9, do: cover(true)
+  defp var_name_char?(?-), do: cover(true)
+  defp var_name_char?(_), do: cover(false)
+
+  defp read_optional_value(remainder) do
+    remainder = Enum.drop_while(remainder, &whitespace?/1)
+
+    if List.first(remainder) == ?= do
+      {value, remainder} =
+        remainder
+        |> Enum.drop(1)
+        |> Enum.drop_while(&whitespace?/1)
+        |> read_possibly_quoted_string()
+
+      cover {ParseCharlist.decode_ambiguous_charlist(value), remainder}
+    else
+      cover {nil, remainder}
+    end
+  end
+
+  defp read_possibly_quoted_string(remainder) do
+    # TOTALLY NAIVE IMPLEMENTATION: Read non-whitespace chars only.
+
+    Enum.split_while(remainder, &(!whitespace?(&1)))
+  end
+
+  defp maybe_config_entry(_section, _subsection, nil = _var_name, _value), do: cover(nil)
+
+  defp maybe_config_entry(nil = _section, _subsection, var_name, _value) do
+    raise ArgumentError,
+          "Invalid config file: Assigning variable #{var_name} without a section header"
+  end
+
+  defp maybe_config_entry(section, subsection, var_name, value) when is_binary(section) do
+    cover(%ConfigEntry{section: section, subsection: subsection, name: var_name, value: value})
+  end
+
+  defp empty_config, do: cover([])
+
+  ## --- Callbacks ---
+
+  @impl true
+  def handle_call({:get_entries, opts}, _from, state), do: handle_get_entries(state, opts)
+
+  def handle_call(message, _from, state) do
+    Logger.warn("ConfigFile received unrecognized call #{inspect(message)}")
+    {:reply, {:error, :unknown_message}, state}
+  end
+end

--- a/lib/xgit/util/config_file.ex
+++ b/lib/xgit/util/config_file.ex
@@ -44,8 +44,10 @@ defmodule Xgit.Util.ConfigFile do
   end
 
   @impl true
-  def init(path) when is_binary(path),
-    do: {:ok, ObservedFile.initial_state_for_path(path, &parse_config_at_path/1, &empty_config/0)}
+  def init(path) when is_binary(path) do
+    cover {:ok,
+           ObservedFile.initial_state_for_path(path, &parse_config_at_path/1, &empty_config/0)}
+  end
 
   @typedoc ~S"""
   Error codes that can be returned by `get_entries/2`.

--- a/test/support/test/test_file_utils.ex
+++ b/test/support/test/test_file_utils.ex
@@ -8,6 +8,6 @@ defmodule Xgit.Test.TestFileUtils do
   Anyone calling this function has to pinky-swear that they will not modify
   the file within the next three seconds.
   """
-  @spec touch_back!(path :: Path.t) :: :ok
+  @spec touch_back!(path :: Path.t()) :: :ok
   def touch_back!(path), do: File.touch!(path, System.os_time(:second) - 3)
 end

--- a/test/support/test/test_file_utils.ex
+++ b/test/support/test/test_file_utils.ex
@@ -8,5 +8,6 @@ defmodule Xgit.Test.TestFileUtils do
   Anyone calling this function has to pinky-swear that they will not modify
   the file within the next three seconds.
   """
+  @spec touch_back!(path :: Path.t) :: :ok
   def touch_back!(path), do: File.touch!(path, System.os_time(:second) - 3)
 end

--- a/test/support/test/test_file_utils.ex
+++ b/test/support/test/test_file_utils.ex
@@ -1,0 +1,12 @@
+defmodule Xgit.Test.TestFileUtils do
+  @moduledoc false
+  # (Testing only) Utils to hack on files
+
+  @doc ~S"""
+  Touch a file such that it precedes any "racy git" condition.
+
+  Anyone calling this function has to pinky-swear that they will not modify
+  the file within the next three seconds.
+  """
+  def touch_back!(path), do: File.touch!(path, System.os_time(:second) - 3)
+end

--- a/test/xgit/util/config_file_test.exs
+++ b/test/xgit/util/config_file_test.exs
@@ -1,0 +1,121 @@
+defmodule Xgit.Util.ConfigFileTest do
+  use ExUnit.Case, async: true
+
+  alias Xgit.ConfigEntry
+  alias Xgit.Test.TempDirTestCase
+  alias Xgit.Test.TestFileUtils
+  alias Xgit.Util.ConfigFile
+
+  describe "start_link/1 + get_entries/1" do
+    test "error: parent dir does not exist" do
+      %{tmp_dir: tmp_dir} = TempDirTestCase.tmp_dir!()
+      path = Path.join(tmp_dir, "config/blah")
+
+      assert_raise ArgumentError,
+                   "Xgit.Util.ConfigFile.start_link/1: Parent of path #{path} must be an existing directory",
+                   fn -> ConfigFile.start_link(path) end
+    end
+
+    test "file does not exist" do
+      %{tmp_dir: tmp_dir} = TempDirTestCase.tmp_dir!()
+      path = Path.join(tmp_dir, "config")
+      refute File.exists?(path)
+
+      assert {:ok, cf} = ConfigFile.start_link(path)
+      assert is_pid(cf)
+
+      assert {:ok, []} = ConfigFile.get_entries(cf)
+    end
+
+    test "simple file exists" do
+      assert entries_from_config_file!(~s"""
+             [core]
+             \trepositoryformatversion = 0
+             \tfilemode = true
+             \tbare = false
+             \tlogallrefupdates = true
+             """) == [
+               %ConfigEntry{
+                 name: "repositoryformatversion",
+                 section: "core",
+                 subsection: nil,
+                 value: "0"
+               },
+               %ConfigEntry{
+                 name: "filemode",
+                 section: "core",
+                 subsection: nil,
+                 value: "true"
+               },
+               %ConfigEntry{
+                 name: "bare",
+                 section: "core",
+                 subsection: nil,
+                 value: "false"
+               },
+               %ConfigEntry{
+                 name: "logallrefupdates",
+                 section: "core",
+                 subsection: nil,
+                 value: "true"
+               }
+             ]
+    end
+
+    test "joins lines with trailing backslash" do
+      assert entries_from_config_file!(~s"""
+             [core]
+             \trepositoryformatversion = 0
+             \tfilemode = true
+             \tbare = false
+             \tlogallrefupdates = true
+             \twhatever = abc\\
+             def
+             """) == [
+               %ConfigEntry{
+                 name: "repositoryformatversion",
+                 section: "core",
+                 subsection: nil,
+                 value: "0"
+               },
+               %ConfigEntry{
+                 name: "filemode",
+                 section: "core",
+                 subsection: nil,
+                 value: "true"
+               },
+               %ConfigEntry{
+                 name: "bare",
+                 section: "core",
+                 subsection: nil,
+                 value: "false"
+               },
+               %ConfigEntry{
+                 name: "logallrefupdates",
+                 section: "core",
+                 subsection: nil,
+                 value: "true"
+               },
+               %ConfigEntry{
+                 name: "whatever",
+                 section: "core",
+                 subsection: nil,
+                 value: "abc\ndef"
+               }
+             ]
+    end
+  end
+
+  defp entries_from_config_file!(config_file) do
+    %{tmp_dir: tmp_dir} = TempDirTestCase.tmp_dir!()
+    config_path = Path.join(tmp_dir, "config")
+
+    File.write!(config_path, config_file)
+    TestFileUtils.touch_back!(config_path)
+
+    assert {:ok, cf} = ConfigFile.start_link(config_path)
+    assert {:ok, entries} = ConfigFile.get_entries(cf)
+
+    entries
+  end
+end

--- a/test/xgit/util/config_file_test.exs
+++ b/test/xgit/util/config_file_test.exs
@@ -224,6 +224,77 @@ defmodule Xgit.Util.ConfigFileTest do
                }
              ]
     end
+
+    test "can parse subsection name" do
+      assert entries_from_config_file!(~s"""
+             [foo "zip"]
+             bar
+             [foo "zap"]
+             bar=false
+             n=3
+             """) == [
+               %ConfigEntry{name: "bar", section: "foo", subsection: "zip", value: nil},
+               %ConfigEntry{name: "bar", section: "foo", subsection: "zap", value: "false"},
+               %ConfigEntry{name: "n", section: "foo", subsection: "zap", value: "3"}
+             ]
+    end
+
+    test "error: incomplete section name" do
+      assert {%RuntimeError{message: "Illegal section header [foo"}, _} =
+               raise_entries_from_config_file!(~s"""
+               [foo
+               bar
+               """)
+    end
+
+    test "subsection name can have escaped double quote" do
+      assert entries_from_config_file!(~s"""
+             [foo "z\\\"ip"]
+             bar
+             [foo "zap"]
+             bar=false
+             n=3
+             """) == [
+               %ConfigEntry{name: "bar", section: "foo", subsection: ~S(z"ip), value: nil},
+               %ConfigEntry{name: "bar", section: "foo", subsection: "zap", value: "false"},
+               %ConfigEntry{name: "n", section: "foo", subsection: "zap", value: "3"}
+             ]
+    end
+
+    test "subsection name can have escaped backslash" do
+      assert entries_from_config_file!(~s"""
+             [foo "z\\\\ip"]
+             bar
+             [foo "zap"]
+             bar=false
+             n=3
+             """) == [
+               %ConfigEntry{name: "bar", section: "foo", subsection: ~S(z\ip), value: nil},
+               %ConfigEntry{name: "bar", section: "foo", subsection: "zap", value: "false"},
+               %ConfigEntry{name: "n", section: "foo", subsection: "zap", value: "3"}
+             ]
+    end
+
+    test "error: incomplete subsection name" do
+      assert {%RuntimeError{message: "Illegal quoted string: Missing close quote"}, _} =
+               raise_entries_from_config_file!(~s"""
+               [foo "abc
+               bar
+               """)
+    end
+
+    test "variable name + value can follow section header" do
+      assert entries_from_config_file!(~s"""
+             [foo "zip"] bar=42
+             [foo "zap"]
+             bar=false
+             n=3
+             """) == [
+               %ConfigEntry{name: "bar", section: "foo", subsection: "zip", value: "42"},
+               %ConfigEntry{name: "bar", section: "foo", subsection: "zap", value: "false"},
+               %ConfigEntry{name: "n", section: "foo", subsection: "zap", value: "3"}
+             ]
+    end
   end
 
   defp entries_from_config_file!(config_file) do
@@ -237,5 +308,17 @@ defmodule Xgit.Util.ConfigFileTest do
     assert {:ok, entries} = ConfigFile.get_entries(cf)
 
     entries
+  end
+
+  defp raise_entries_from_config_file!(config_file) do
+    %{tmp_dir: tmp_dir} = TempDirTestCase.tmp_dir!()
+    config_path = Path.join(tmp_dir, "config")
+
+    File.write!(config_path, config_file)
+    TestFileUtils.touch_back!(config_path)
+
+    assert {:error, error} = ConfigFile.start_link(config_path)
+
+    error
   end
 end

--- a/test/xgit/util/config_file_test.exs
+++ b/test/xgit/util/config_file_test.exs
@@ -584,6 +584,38 @@ defmodule Xgit.Util.ConfigFileTest do
                }
              ]
     end
+
+    test "re-reads file when updated" do
+      %{tmp_dir: tmp_dir} = TempDirTestCase.tmp_dir!()
+      config_path = Path.join(tmp_dir, "config")
+
+      File.write!(config_path, ~s([foo "zip"] bar = 42))
+      TestFileUtils.touch_back!(config_path)
+
+      assert {:ok, cf} = ConfigFile.start_link(config_path)
+
+      assert {:ok,
+              [
+                %ConfigEntry{
+                  name: "bar",
+                  section: "foo",
+                  subsection: "zip",
+                  value: "42"
+                }
+              ]} = ConfigFile.get_entries(cf)
+
+      File.write!(config_path, ~s([foo "zip"] bar = 44))
+
+      assert {:ok,
+              [
+                %ConfigEntry{
+                  name: "bar",
+                  section: "foo",
+                  subsection: "zip",
+                  value: "44"
+                }
+              ]} = ConfigFile.get_entries(cf)
+    end
   end
 
   defp entries_from_config_file!(config_file) do

--- a/test/xgit/util/config_file_test.exs
+++ b/test/xgit/util/config_file_test.exs
@@ -211,6 +211,17 @@ defmodule Xgit.Util.ConfigFileTest do
              ]
     end
 
+    test "error: section name must precede a variable declaration" do
+      assert {%ArgumentError{
+                message:
+                  ~s(Invalid config file: Assigning variable mumble without a section header)
+              },
+              _} =
+               raise_entries_from_config_file!(~s"""
+               mumble = 25
+               """)
+    end
+
     test "accepts missing value" do
       assert entries_from_config_file!(~s"""
              [foo]
@@ -240,7 +251,7 @@ defmodule Xgit.Util.ConfigFileTest do
     end
 
     test "error: incomplete section name" do
-      assert {%RuntimeError{message: "Illegal section header [foo"}, _} =
+      assert {%ArgumentError{message: "Illegal section header [foo"}, _} =
                raise_entries_from_config_file!(~s"""
                [foo
                bar
@@ -276,7 +287,7 @@ defmodule Xgit.Util.ConfigFileTest do
     end
 
     test "error: incomplete subsection name" do
-      assert {%RuntimeError{message: "Illegal quoted string: Missing close quote"}, _} =
+      assert {%ArgumentError{message: "Illegal quoted string: Missing close quote"}, _} =
                raise_entries_from_config_file!(~s"""
                [foo "abc
                bar
@@ -306,7 +317,7 @@ defmodule Xgit.Util.ConfigFileTest do
     end
 
     test "error: variable names may not contain other characters" do
-      assert {%RuntimeError{
+      assert {%ArgumentError{
                 message: ~s(Illegal variable declaration: [foo "zip"] mumble.more = 25)
               },
               _} =

--- a/test/xgit/util/config_file_test.exs
+++ b/test/xgit/util/config_file_test.exs
@@ -294,6 +294,14 @@ defmodule Xgit.Util.ConfigFileTest do
                """)
     end
 
+    test "error: subsection name can not contain new line" do
+      assert {%ArgumentError{message: "Illegal quoted string: Can not span a new line"}, _} =
+               raise_entries_from_config_file!(~S"""
+               [foo "abc\
+               bar"]
+               """)
+    end
+
     test "variable name can contain numbers" do
       assert entries_from_config_file!(~s"""
              [foo "zip"] two5 = 25

--- a/test/xgit/util/config_file_test.exs
+++ b/test/xgit/util/config_file_test.exs
@@ -104,6 +104,62 @@ defmodule Xgit.Util.ConfigFileTest do
                }
              ]
     end
+
+    test "ignores whitespace" do
+      assert entries_from_config_file!(~s"""
+             \t[core]
+             repositoryformatversion=0
+              filemode= true
+                bare=   false
+             \t logallrefupdates\t=\ttrue
+             \twhatever = abc
+             """) == [
+               %ConfigEntry{
+                 name: "repositoryformatversion",
+                 section: "core",
+                 subsection: nil,
+                 value: "0"
+               },
+               %ConfigEntry{
+                 name: "filemode",
+                 section: "core",
+                 subsection: nil,
+                 value: "true"
+               },
+               %ConfigEntry{
+                 name: "bare",
+                 section: "core",
+                 subsection: nil,
+                 value: "false"
+               },
+               %ConfigEntry{
+                 name: "logallrefupdates",
+                 section: "core",
+                 subsection: nil,
+                 value: "true"
+               },
+               %ConfigEntry{
+                 name: "whatever",
+                 section: "core",
+                 subsection: nil,
+                 value: "abc"
+               }
+             ]
+    end
+
+    test "accepts missing value" do
+      assert entries_from_config_file!(~s"""
+             [foo]
+             bar
+             """) == [
+               %ConfigEntry{
+                 name: "bar",
+                 section: "foo",
+                 subsection: nil,
+                 value: nil
+               }
+             ]
+    end
   end
 
   defp entries_from_config_file!(config_file) do

--- a/test/xgit/util/config_file_test.exs
+++ b/test/xgit/util/config_file_test.exs
@@ -295,6 +295,35 @@ defmodule Xgit.Util.ConfigFileTest do
                %ConfigEntry{name: "n", section: "foo", subsection: "zap", value: "3"}
              ]
     end
+
+    test "unquoted values strip leading whitespace" do
+      assert entries_from_config_file!(~s"""
+             [foo "zip"]
+                bar =    42
+             """) == [
+               %ConfigEntry{name: "bar", section: "foo", subsection: "zip", value: "42"}
+             ]
+    end
+
+    test "unquoted values strip trailing whitespace" do
+      assert entries_from_config_file!("[foo \"zip\"] bar =42   ") == [
+               %ConfigEntry{name: "bar", section: "foo", subsection: "zip", value: "42"}
+             ]
+    end
+
+    test "internal whitespace is preserved verbatim" do
+      assert entries_from_config_file!(~s"""
+             [foo "zip"]
+                bar = 42   and then\tsome
+             """) == [
+               %ConfigEntry{
+                 name: "bar",
+                 section: "foo",
+                 subsection: "zip",
+                 value: "42   and then\tsome"
+               }
+             ]
+    end
   end
 
   defp entries_from_config_file!(config_file) do

--- a/test/xgit/util/config_file_test.exs
+++ b/test/xgit/util/config_file_test.exs
@@ -147,6 +147,70 @@ defmodule Xgit.Util.ConfigFileTest do
              ]
     end
 
+    test "section names are not case-sensitive" do
+      assert entries_from_config_file!(~s"""
+             [coRe]
+             \trepositoryformatversion = 0
+             """) == [
+               %ConfigEntry{
+                 name: "repositoryformatversion",
+                 section: "core",
+                 subsection: nil,
+                 value: "0"
+               }
+             ]
+    end
+
+    test "only alphanumeric characters, -, and . are allowed in section names" do
+      assert entries_from_config_file!(~s"""
+             [core.foo]
+             \trepositoryformatversion = 0
+             """) == [
+               %ConfigEntry{
+                 name: "repositoryformatversion",
+                 section: "core.foo",
+                 subsection: nil,
+                 value: "0"
+               }
+             ]
+
+      assert entries_from_config_file!(~s"""
+             [core-foo]
+             \trepositoryformatversion = 0
+             """) == [
+               %ConfigEntry{
+                 name: "repositoryformatversion",
+                 section: "core-foo",
+                 subsection: nil,
+                 value: "0"
+               }
+             ]
+
+      assert entries_from_config_file!(~s"""
+             [core9]
+             \trepositoryformatversion = 0
+             """) == [
+               %ConfigEntry{
+                 name: "repositoryformatversion",
+                 section: "core9",
+                 subsection: nil,
+                 value: "0"
+               }
+             ]
+
+      assert entries_from_config_file!(~s"""
+             [9core]
+             \trepositoryformatversion = 0
+             """) == [
+               %ConfigEntry{
+                 name: "repositoryformatversion",
+                 section: "9core",
+                 subsection: nil,
+                 value: "0"
+               }
+             ]
+    end
+
     test "accepts missing value" do
       assert entries_from_config_file!(~s"""
              [foo]


### PR DESCRIPTION
## Changes in This Pull Request
`Xgit.Util.ConfigFile` implements the reading of the [`git config`](https://git-scm.com/docs/git-config/1.8.2#_syntax) file format. (Writing will follow soon.)
 
## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] There is test coverage for all changes.
- [x] All cases where a literal value is returned use the `cover` macro to force code coverage.
- ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
