### PR TITLE
ConfigFile: Add a test for multi-valued variables.

### DIFF
--- a/test/xgit/util/config_file_test.exs
+++ b/test/xgit/util/config_file_test.exs
@@ -107,6 +107,48 @@ defmodule Xgit.Util.ConfigFileTest do
              ]
     end
 
+    test "understands multi-valued variables" do
+      assert entries_from_config_file!(~s"""
+             [core]
+             \trepositoryformatversion = 0
+             \tfilemode = true
+             \tbare = false
+             \tgitproxy = command1
+             \tgitproxy = command2
+             """) == [
+               %ConfigEntry{
+                 name: "repositoryformatversion",
+                 section: "core",
+                 subsection: nil,
+                 value: "0"
+               },
+               %ConfigEntry{
+                 name: "filemode",
+                 section: "core",
+                 subsection: nil,
+                 value: "true"
+               },
+               %ConfigEntry{
+                 name: "bare",
+                 section: "core",
+                 subsection: nil,
+                 value: "false"
+               },
+               %ConfigEntry{
+                 name: "gitproxy",
+                 section: "core",
+                 subsection: nil,
+                 value: "command1"
+               },
+               %ConfigEntry{
+                 name: "gitproxy",
+                 section: "core",
+                 subsection: nil,
+                 value: "command2"
+               }
+             ]
+    end
+
     test "ignores whitespace" do
       assert entries_from_config_file!(~s"""
              \t[core]


### PR DESCRIPTION
## Changes in This Pull Request
I forgot to add a test for `Xgit.Util.ConfigFile` to ensure it could handle multi-valued variables. Added now.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- ~All applicable changes have been documented.~ _n/a_
- [x] There is test coverage for all changes.
- ~All cases where a literal value is returned use the `cover` macro to force code coverage.~ _n/a_
- ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
