### PR TITLE
Implement Xgit.Util.ConfigFile.add_entries/3.

### DIFF
--- a/lib/xgit/util/config_file.ex
+++ b/lib/xgit/util/config_file.ex
@@ -321,9 +321,9 @@ defmodule Xgit.Util.ConfigFile do
   defp empty_config, do: cover([])
 
   @typedoc ~S"""
-  Error codes that can be returned by `add_config_entries/3`.
+  Error codes that can be returned by `add_entries/3`.
   """
-  @type add_config_entries_reason :: File.posix() | :replacing_multivar
+  @type add_entries_reason :: File.posix() | :replacing_multivar
 
   @doc ~S"""
   Add one or more new entries to an existing config.
@@ -352,27 +352,27 @@ defmodule Xgit.Util.ConfigFile do
 
   `{:error, reason}` if unable. `reason` is likely a POSIX error code.
   """
-  @spec add_config_entries(config_file :: t, entries :: [Xgit.ConfigEntry.t()],
+  @spec add_entries(config_file :: t, entries :: [Xgit.ConfigEntry.t()],
           add?: boolean,
           replace_all?: boolean
         ) ::
-          :ok | {:error, config_file :: add_config_entries_reason}
-  def add_config_entries(config_file, entries, opts \\ [])
+          :ok | {:error, config_file :: add_entries_reason}
+  def add_entries(config_file, entries, opts \\ [])
       when is_pid(config_file) and is_list(entries) and is_list(opts) do
     if Keyword.get(opts, :add?) && Keyword.get(opts, :replace_all?) do
       raise ArgumentError,
-            "Xgit.Util.ConfigFile.add_config_entries/3: add? and replace_all? can not both be true"
+            "Xgit.Util.ConfigFile.add_entries/3: add? and replace_all? can not both be true"
     end
 
     if Enum.all?(entries, &ConfigEntry.valid?/1) do
-      GenServer.call(config_file, {:add_config_entries, entries, opts})
+      GenServer.call(config_file, {:add_entries, entries, opts})
     else
       raise ArgumentError,
-            "Xgit.Util.ConfigFile.add_config_entries/3: one or more entries are invalid"
+            "Xgit.Util.ConfigFile.add_entries/3: one or more entries are invalid"
     end
   end
 
-  defp handle_add_config_entries(%ObservedFile{path: path} = of, entries, opts) do
+  defp handle_add_entries(%ObservedFile{path: path} = of, entries, opts) do
     %{parsed_state: lines} =
       of = ObservedFile.update_state_if_maybe_dirty(of, &parse_config_at_path/1, &empty_config/0)
 
@@ -612,8 +612,8 @@ defmodule Xgit.Util.ConfigFile do
   @impl true
   def handle_call({:get_entries, opts}, _from, state), do: handle_get_entries(state, opts)
 
-  def handle_call({:add_config_entries, entries, opts}, _from, state),
-    do: handle_add_config_entries(state, entries, opts)
+  def handle_call({:add_entries, entries, opts}, _from, state),
+    do: handle_add_entries(state, entries, opts)
 
   def handle_call(message, _from, state) do
     Logger.warn("ConfigFile received unrecognized call #{inspect(message)}")

--- a/lib/xgit/util/config_file.ex
+++ b/lib/xgit/util/config_file.ex
@@ -576,9 +576,19 @@ defmodule Xgit.Util.ConfigFile do
   defp maybe_insert_subsection(_line, section, nil),
     do: cover([%__MODULE__.Line{original: "[#{section}]", section: section}])
 
-  defp maybe_insert_subsection(_line, _section, _subsection) do
-    raise "subsection unimplemented"
-    # TO DO: Needs quoting and escaping
+  defp maybe_insert_subsection(_line, section, subsection) do
+    escaped_subsection =
+      subsection
+      |> String.replace("\\", "\\\\")
+      |> String.replace(~S("), ~S(\"))
+
+    cover([
+      %__MODULE__.Line{
+        original: ~s([#{section} "#{escaped_subsection}"]),
+        section: section,
+        subsection: subsection
+      }
+    ])
   end
 
   defp entry_to_line(

--- a/lib/xgit/util/config_file.ex
+++ b/lib/xgit/util/config_file.ex
@@ -364,8 +364,14 @@ defmodule Xgit.Util.ConfigFile do
     end
   end
 
-  defp handle_add_config_entries(%ObservedFile{} = _of, _entries, _opts) do
-    raise "unimplemented"
+  defp handle_add_config_entries(%ObservedFile{} = of, _entries, opts) do
+    %{parsed_state: lines} =
+      of = ObservedFile.update_state_if_maybe_dirty(of, &parse_config_at_path/1, &empty_config/0)
+
+    add? = Keyword.get(opts, :add?, false)
+    replace_all? = Keyword.get(opts, :replace_all?, false)
+
+      raise "unimplemented"
   end
 
   ## --- Callbacks ---

--- a/lib/xgit/util/config_file.ex
+++ b/lib/xgit/util/config_file.ex
@@ -516,10 +516,6 @@ defmodule Xgit.Util.ConfigFile do
         Enum.map(matching_entries_to_add, &entry_to_line/1)
 
     {new_lines, remaining_lines, other_entries_to_add}
-
-    # IO.inspect(new_lines, label: "new_lines")
-
-    # raise "argh, my head asplode!"
   end
 
   defp new_lines(

--- a/lib/xgit/util/config_file.ex
+++ b/lib/xgit/util/config_file.ex
@@ -371,7 +371,7 @@ defmodule Xgit.Util.ConfigFile do
     add? = Keyword.get(opts, :add?, false)
     replace_all? = Keyword.get(opts, :replace_all?, false)
 
-      raise "unimplemented"
+    raise "unimplemented"
   end
 
   ## --- Callbacks ---

--- a/lib/xgit/util/config_file.ex
+++ b/lib/xgit/util/config_file.ex
@@ -241,7 +241,7 @@ defmodule Xgit.Util.ConfigFile do
 
   defp read_quoted_string([?" | remainder]) do
     {quoted_string, remainder} = read_quoted_string([], remainder)
-    {Enum.reverse(quoted_string), remainder}
+    cover {Enum.reverse(quoted_string), remainder}
   end
 
   defp read_quoted_string(_acc, [?\n | _remainder]) do

--- a/test/xgit/util/config_file_test.exs
+++ b/test/xgit/util/config_file_test.exs
@@ -861,7 +861,7 @@ defmodule Xgit.Util.ConfigFileTest do
         end,
         xgit_add_fn: fn config_file ->
           assert :ok =
-                   ConfigFile.add_config_entries(
+                   ConfigFile.add_entries(
                      config_file,
                      [
                        %ConfigEntry{
@@ -885,7 +885,7 @@ defmodule Xgit.Util.ConfigFileTest do
         end,
         xgit_add_fn: fn config_file ->
           assert :ok =
-                   ConfigFile.add_config_entries(
+                   ConfigFile.add_entries(
                      config_file,
                      [
                        %ConfigEntry{
@@ -915,7 +915,7 @@ defmodule Xgit.Util.ConfigFileTest do
         end,
         xgit_add_fn: fn config_file ->
           assert :ok =
-                   ConfigFile.add_config_entries(
+                   ConfigFile.add_entries(
                      config_file,
                      [
                        %ConfigEntry{
@@ -939,7 +939,7 @@ defmodule Xgit.Util.ConfigFileTest do
         end,
         xgit_add_fn: fn config_file ->
           assert :ok =
-                   ConfigFile.add_config_entries(
+                   ConfigFile.add_entries(
                      config_file,
                      [
                        %ConfigEntry{
@@ -962,7 +962,7 @@ defmodule Xgit.Util.ConfigFileTest do
         end,
         xgit_add_fn: fn config_file ->
           assert :ok =
-                   ConfigFile.add_config_entries(
+                   ConfigFile.add_entries(
                      config_file,
                      [
                        %ConfigEntry{
@@ -991,7 +991,7 @@ defmodule Xgit.Util.ConfigFileTest do
         end,
         xgit_add_fn: fn config_file ->
           assert :ok =
-                   ConfigFile.add_config_entries(
+                   ConfigFile.add_entries(
                      config_file,
                      [
                        %ConfigEntry{
@@ -1025,7 +1025,7 @@ defmodule Xgit.Util.ConfigFileTest do
         end,
         xgit_add_fn: fn config_file ->
           assert :ok =
-                   ConfigFile.add_config_entries(
+                   ConfigFile.add_entries(
                      config_file,
                      [
                        %ConfigEntry{
@@ -1047,7 +1047,7 @@ defmodule Xgit.Util.ConfigFileTest do
       assert {:ok, cf} = ConfigFile.start_link(config_file_path)
 
       assert {:error, :replacing_multivar} =
-               ConfigFile.add_config_entries(
+               ConfigFile.add_entries(
                  cf,
                  [
                    %ConfigEntry{
@@ -1082,9 +1082,9 @@ defmodule Xgit.Util.ConfigFileTest do
       assert {:ok, cf} = ConfigFile.start_link(config_file_path)
 
       assert_raise ArgumentError,
-                   "Xgit.Util.ConfigFile.add_config_entries/3: add? and replace_all? can not both be true",
+                   "Xgit.Util.ConfigFile.add_entries/3: add? and replace_all? can not both be true",
                    fn ->
-                     ConfigFile.add_config_entries(
+                     ConfigFile.add_entries(
                        cf,
                        [
                          %ConfigEntry{
@@ -1106,9 +1106,9 @@ defmodule Xgit.Util.ConfigFileTest do
       assert {:ok, cf} = ConfigFile.start_link(config_file_path)
 
       assert_raise ArgumentError,
-                   "Xgit.Util.ConfigFile.add_config_entries/3: one or more entries are invalid",
+                   "Xgit.Util.ConfigFile.add_entries/3: one or more entries are invalid",
                    fn ->
-                     ConfigFile.add_config_entries(
+                     ConfigFile.add_entries(
                        cf,
                        [
                          %ConfigEntry{

--- a/test/xgit/util/config_file_test.exs
+++ b/test/xgit/util/config_file_test.exs
@@ -1126,8 +1126,7 @@ defmodule Xgit.Util.ConfigFileTest do
   defp assert_configs_are_equal(opts) do
     initial_config = Keyword.get(opts, :initial_config)
 
-    %{xgit_path: ref_path} =
-      setup_with_config!(initial_config: initial_config)
+    %{xgit_path: ref_path} = setup_with_config!(initial_config: initial_config)
 
     %{xgit_path: xgit_path, config_file_path: xgit_config_file_path} =
       setup_with_config!(initial_config: initial_config)

--- a/test/xgit/util/config_file_test.exs
+++ b/test/xgit/util/config_file_test.exs
@@ -1127,10 +1127,10 @@ defmodule Xgit.Util.ConfigFileTest do
     initial_config = Keyword.get(opts, :initial_config)
 
     %{xgit_path: ref_path} =
-      setup_with_config!(initial_config: initial_config, path: "/Users/scouten/Desktop/ref")
+      setup_with_config!(initial_config: initial_config)
 
     %{xgit_path: xgit_path, config_file_path: xgit_config_file_path} =
-      setup_with_config!(initial_config: initial_config, path: "/Users/scouten/Desktop/xgit")
+      setup_with_config!(initial_config: initial_config)
 
     git_add_fn = Keyword.get(opts, :git_add_fn)
     git_add_fn.(ref_path)

--- a/test/xgit/util/config_file_test.exs
+++ b/test/xgit/util/config_file_test.exs
@@ -895,7 +895,7 @@ defmodule Xgit.Util.ConfigFileTest do
     xgit_add_fn = Keyword.get(opts, :xgit_add_fn)
     xgit_add_fn.(xgit_config_file)
 
-    assert_folders_are_equal(Path.join(ref_path), Path.join(xgit_path))
+    assert_folders_are_equal(Path.join(ref_path, ".git"), Path.join(xgit_path, ".git"))
   end
 
   defp setup_with_config!(opts) do

--- a/test/xgit/util/config_file_test.exs
+++ b/test/xgit/util/config_file_test.exs
@@ -906,6 +906,54 @@ defmodule Xgit.Util.ConfigFileTest do
       )
     end
 
+    test "creating a new subsection" do
+      assert_configs_are_equal(
+        initial_config: @example_config,
+        git_add_fn: fn path ->
+          assert {"", 0} =
+                   System.cmd("git", ["config", "other.mumble.filemode", "true"], cd: path)
+        end,
+        xgit_add_fn: fn config_file ->
+          assert :ok =
+                   ConfigFile.add_config_entries(
+                     config_file,
+                     [
+                       %ConfigEntry{
+                         section: "other",
+                         subsection: "mumble",
+                         name: "filemode",
+                         value: "true"
+                       }
+                     ]
+                   )
+        end
+      )
+    end
+
+    test "creating a new subsection requiring escaping" do
+      assert_configs_are_equal(
+        initial_config: @example_config,
+        git_add_fn: fn path ->
+          assert {"", 0} =
+                   System.cmd("git", ["config", ~s(other.mu"mb"\\le.filemode), "true"], cd: path)
+        end,
+        xgit_add_fn: fn config_file ->
+          assert :ok =
+                   ConfigFile.add_config_entries(
+                     config_file,
+                     [
+                       %ConfigEntry{
+                         section: "other",
+                         subsection: ~s(mu"mb"\\le),
+                         name: "filemode",
+                         value: "true"
+                       }
+                     ]
+                   )
+        end
+      )
+    end
+
     test "replace single-valued variable with redundant replace_all?: true" do
       assert_configs_are_equal(
         initial_config: @example_config,


### PR DESCRIPTION
## Changes in This Pull Request
This allows the caller to add to an existing config file.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] There is test coverage for all changes.
- [x] All cases where a literal value is returned use the `cover` macro to force code coverage.
- ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
