### PR TITLE
Implement Xgit.Util.ConfigFile.remove_entries/2.

### DIFF
--- a/test/xgit/util/config_file_test.exs
+++ b/test/xgit/util/config_file_test.exs
@@ -1123,6 +1123,20 @@ defmodule Xgit.Util.ConfigFileTest do
     end
   end
 
+  describe "remove_entries/2" do
+    test "clear entire file" do
+      assert_configs_are_equal(
+        initial_config: @example_config,
+        git_add_fn: fn path ->
+          File.write!(Path.join(path, ".git/config"), "")
+        end,
+        xgit_add_fn: fn config_file ->
+          assert :ok = ConfigFile.remove_entries(config_file)
+        end
+      )
+    end
+  end
+
   defp assert_configs_are_equal(opts) do
     initial_config = Keyword.get(opts, :initial_config)
 

--- a/test/xgit/util/config_file_test.exs
+++ b/test/xgit/util/config_file_test.exs
@@ -1135,6 +1135,61 @@ defmodule Xgit.Util.ConfigFileTest do
         end
       )
     end
+
+    test "remove by section" do
+      assert_configs_are_equal(
+        initial_config: @example_config,
+        git_add_fn: fn path ->
+          assert {"", 0} = System.cmd("git", ["config", "--remove-section", "core"], cd: path)
+        end,
+        xgit_add_fn: fn config_file ->
+          assert :ok =
+                   ConfigFile.remove_entries(
+                     config_file,
+                     section: "core"
+                   )
+        end
+      )
+    end
+
+    test "remove by subsection" do
+      assert_configs_are_equal(
+        initial_config: @example_config,
+        git_add_fn: fn path ->
+          assert {"", 0} =
+                   System.cmd(
+                     "git",
+                     ["config", "--remove-section", "http.https://weak.example.com"],
+                     cd: path
+                   )
+        end,
+        xgit_add_fn: fn config_file ->
+          assert :ok =
+                   ConfigFile.remove_entries(
+                     config_file,
+                     section: "http",
+                     subsection: "https://weak.example.com"
+                   )
+        end
+      )
+    end
+
+    test "remove by name" do
+      assert_configs_are_equal(
+        initial_config: @example_config,
+        git_add_fn: fn path ->
+          assert {"", 0} = System.cmd("git", ["config", "--unset-all", "core.filemode"], cd: path)
+        end,
+        xgit_add_fn: fn config_file ->
+          assert :ok =
+                   ConfigFile.remove_entries(
+                     config_file,
+                     section: "core",
+                     name: "filemode"
+                   )
+        end
+      )
+    end
   end
 
   defp assert_configs_are_equal(opts) do


### PR DESCRIPTION
## Changes in This Pull Request
This allows the caller to remove items from an existing config file.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] There is test coverage for all changes.
- [x] All cases where a literal value is returned use the `cover` macro to force code coverage.
- ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
