### PR TITLE
[API BREAKING] Replace Xgit.ConfigFile.add_entries/3 with ConfigFile.update/3.

### DIFF
--- a/lib/xgit/config_file.ex
+++ b/lib/xgit/config_file.ex
@@ -358,7 +358,7 @@ defmodule Xgit.ConfigFile do
           replace_all?: boolean
         ) ::
           :ok | {:error, config_file :: update_reason}
-  def update(config_file, value, opts \\ [])
+  def update(config_file, value, opts)
       when is_pid(config_file) and (is_nil(value) or is_binary(value)) and
              is_list(opts) do
     if Keyword.get(opts, :add?) && Keyword.get(opts, :replace_all?) do

--- a/test/xgit/config_file_test.exs
+++ b/test/xgit/config_file_test.exs
@@ -871,6 +871,24 @@ defmodule Xgit.ConfigFileTest do
       )
     end
 
+    test "creating a new top-level section" do
+      assert_configs_are_equal(
+        config_file_content: @example_config,
+        git_add_fn: fn path ->
+          assert {"", 0} = System.cmd("git", ["config", "other.filemode", "true"], cd: path)
+        end,
+        xgit_add_fn: fn config_file ->
+          assert :ok =
+                   ConfigFile.update(
+                     config_file,
+                     "true",
+                     section: "other",
+                     name: "filemode"
+                   )
+        end
+      )
+    end
+
     test "creating a new subsection" do
       assert_configs_are_equal(
         config_file_content: @example_config,

--- a/test/xgit/config_file_test.exs
+++ b/test/xgit/config_file_test.exs
@@ -863,44 +863,9 @@ defmodule Xgit.ConfigFileTest do
           assert :ok =
                    ConfigFile.add_entries(
                      config_file,
-                     [
-                       %ConfigEntry{
-                         section: "core",
-                         subsection: nil,
-                         name: "filemode",
-                         value: "true"
-                       }
-                     ]
-                   )
-        end
-      )
-    end
-
-    test "add multiple entries in different sections" do
-      assert_configs_are_equal(
-        config_file_content: @example_config,
-        git_add_fn: fn path ->
-          assert {"", 0} = System.cmd("git", ["config", "core.filemode", "true"], cd: path)
-          assert {"", 0} = System.cmd("git", ["config", "other.mumble", "42"], cd: path)
-        end,
-        xgit_add_fn: fn config_file ->
-          assert :ok =
-                   ConfigFile.add_entries(
-                     config_file,
-                     [
-                       %ConfigEntry{
-                         section: "core",
-                         subsection: nil,
-                         name: "filemode",
-                         value: "true"
-                       },
-                       %ConfigEntry{
-                         section: "other",
-                         subsection: nil,
-                         name: "mumble",
-                         value: "42"
-                       }
-                     ]
+                     "true",
+                     section: "core",
+                     name: "filemode"
                    )
         end
       )
@@ -917,14 +882,10 @@ defmodule Xgit.ConfigFileTest do
           assert :ok =
                    ConfigFile.add_entries(
                      config_file,
-                     [
-                       %ConfigEntry{
-                         section: "other",
-                         subsection: "mumble",
-                         name: "filemode",
-                         value: "true"
-                       }
-                     ]
+                     "true",
+                     section: "other",
+                     subsection: "mumble",
+                     name: "filemode"
                    )
         end
       )
@@ -941,14 +902,10 @@ defmodule Xgit.ConfigFileTest do
           assert :ok =
                    ConfigFile.add_entries(
                      config_file,
-                     [
-                       %ConfigEntry{
-                         section: "other",
-                         subsection: ~s(mu"mb"\\le),
-                         name: "filemode",
-                         value: "true"
-                       }
-                     ]
+                     "true",
+                     section: "other",
+                     subsection: ~s(mu"mb"\\le),
+                     name: "filemode"
                    )
         end
       )
@@ -964,14 +921,9 @@ defmodule Xgit.ConfigFileTest do
           assert :ok =
                    ConfigFile.add_entries(
                      config_file,
-                     [
-                       %ConfigEntry{
-                         section: "core",
-                         subsection: nil,
-                         name: "filemode",
-                         value: "true"
-                       }
-                     ],
+                     "true",
+                     section: "core",
+                     name: "filemode",
                      replace_all?: true
                    )
         end
@@ -993,14 +945,9 @@ defmodule Xgit.ConfigFileTest do
           assert :ok =
                    ConfigFile.add_entries(
                      config_file,
-                     [
-                       %ConfigEntry{
-                         section: "core",
-                         subsection: nil,
-                         name: "gitproxy",
-                         value: ~s("proxy-command" for example.com)
-                       }
-                     ],
+                     ~s("proxy-command" for example.com),
+                     section: "core",
+                     name: "gitproxy",
                      add?: true
                    )
         end
@@ -1027,14 +974,9 @@ defmodule Xgit.ConfigFileTest do
           assert :ok =
                    ConfigFile.add_entries(
                      config_file,
-                     [
-                       %ConfigEntry{
-                         section: "core",
-                         subsection: nil,
-                         name: "gitproxy",
-                         value: ~s("proxy-command" for example.com)
-                       }
-                     ],
+                     ~s("proxy-command" for example.com),
+                     section: "core",
+                     name: "gitproxy",
                      replace_all?: true
                    )
         end
@@ -1050,14 +992,9 @@ defmodule Xgit.ConfigFileTest do
       assert {:error, :replacing_multivar} =
                ConfigFile.add_entries(
                  cf,
-                 [
-                   %ConfigEntry{
-                     section: "core",
-                     subsection: nil,
-                     name: "gitproxy",
-                     value: ~s("proxy-command" for example.com)
-                   }
-                 ]
+                 ~s("proxy-command" for example.com),
+                 section: "core",
+                 name: "gitproxy"
                )
 
       assert {:ok,
@@ -1088,14 +1025,9 @@ defmodule Xgit.ConfigFileTest do
                    fn ->
                      ConfigFile.add_entries(
                        cf,
-                       [
-                         %ConfigEntry{
-                           section: "core",
-                           subsection: nil,
-                           name: "filemode",
-                           value: "true"
-                         }
-                       ],
+                       "true",
+                       section: "core",
+                       name: "filemode",
                        add?: true,
                        replace_all?: true
                      )
@@ -1113,14 +1045,9 @@ defmodule Xgit.ConfigFileTest do
                    fn ->
                      ConfigFile.add_entries(
                        cf,
-                       [
-                         %ConfigEntry{
-                           section: "no_underscores_allowed",
-                           subsection: nil,
-                           name: "filemode",
-                           value: "true"
-                         }
-                       ]
+                       "true",
+                       section: "no_underscores_allowed",
+                       name: "filemode"
                      )
                    end
     end

--- a/test/xgit/config_file_test.exs
+++ b/test/xgit/config_file_test.exs
@@ -852,7 +852,7 @@ defmodule Xgit.ConfigFileTest do
     cookieFile = /tmp/cookie.txt
   """
 
-  describe "add_entries/3" do
+  describe "update/3" do
     test "basic case with default options" do
       assert_configs_are_equal(
         config_file_content: @example_config,
@@ -861,7 +861,7 @@ defmodule Xgit.ConfigFileTest do
         end,
         xgit_add_fn: fn config_file ->
           assert :ok =
-                   ConfigFile.add_entries(
+                   ConfigFile.update(
                      config_file,
                      "true",
                      section: "core",
@@ -880,7 +880,7 @@ defmodule Xgit.ConfigFileTest do
         end,
         xgit_add_fn: fn config_file ->
           assert :ok =
-                   ConfigFile.add_entries(
+                   ConfigFile.update(
                      config_file,
                      "true",
                      section: "other",
@@ -900,7 +900,7 @@ defmodule Xgit.ConfigFileTest do
         end,
         xgit_add_fn: fn config_file ->
           assert :ok =
-                   ConfigFile.add_entries(
+                   ConfigFile.update(
                      config_file,
                      "true",
                      section: "other",
@@ -919,7 +919,7 @@ defmodule Xgit.ConfigFileTest do
         end,
         xgit_add_fn: fn config_file ->
           assert :ok =
-                   ConfigFile.add_entries(
+                   ConfigFile.update(
                      config_file,
                      "true",
                      section: "core",
@@ -943,7 +943,7 @@ defmodule Xgit.ConfigFileTest do
         end,
         xgit_add_fn: fn config_file ->
           assert :ok =
-                   ConfigFile.add_entries(
+                   ConfigFile.update(
                      config_file,
                      ~s("proxy-command" for example.com),
                      section: "core",
@@ -972,7 +972,7 @@ defmodule Xgit.ConfigFileTest do
         end,
         xgit_add_fn: fn config_file ->
           assert :ok =
-                   ConfigFile.add_entries(
+                   ConfigFile.update(
                      config_file,
                      ~s("proxy-command" for example.com),
                      section: "core",
@@ -990,7 +990,7 @@ defmodule Xgit.ConfigFileTest do
       assert {:ok, cf} = ConfigFile.start_link(config_file_path)
 
       assert {:error, :replacing_multivar} =
-               ConfigFile.add_entries(
+               ConfigFile.update(
                  cf,
                  ~s("proxy-command" for example.com),
                  section: "core",
@@ -1021,9 +1021,9 @@ defmodule Xgit.ConfigFileTest do
       assert {:ok, cf} = ConfigFile.start_link(config_file_path)
 
       assert_raise ArgumentError,
-                   "Xgit.ConfigFile.add_entries/3: add? and replace_all? can not both be true",
+                   "Xgit.ConfigFile.update/3: add? and replace_all? can not both be true",
                    fn ->
-                     ConfigFile.add_entries(
+                     ConfigFile.update(
                        cf,
                        "true",
                        section: "core",
@@ -1041,9 +1041,9 @@ defmodule Xgit.ConfigFileTest do
       assert {:ok, cf} = ConfigFile.start_link(config_file_path)
 
       assert_raise ArgumentError,
-                   "Xgit.ConfigFile.add_entries/3: one or more entries are invalid",
+                   "Xgit.ConfigFile.update/3: one or more entries are invalid",
                    fn ->
-                     ConfigFile.add_entries(
+                     ConfigFile.update(
                        cf,
                        "true",
                        section: "no_underscores_allowed",


### PR DESCRIPTION
## Changes in This Pull Request
Remove ability to add entries to multiple variables at once. This doesn't exist in the corresponding git command-line interface and unnecessarily complicates other implementations.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] There is test coverage for all changes.
- [x] All cases where a literal value is returned use the `cover` macro to force code coverage.
- ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
