### PR TITLE
Match `git init` behavior of more recent comamnd-line git versions.

### DIFF
--- a/lib/xgit/repository/on_disk.ex
+++ b/lib/xgit/repository/on_disk.ex
@@ -134,7 +134,7 @@ defmodule Xgit.Repository.OnDisk do
   end
 
   defp create_git_dir(git_dir) do
-    with :ok <- create_branches_dir(git_dir),
+    with :ok <- File.mkdir_p(git_dir),
          :ok <- create_config(git_dir),
          :ok <- create_description(git_dir),
          :ok <- create_head(git_dir),
@@ -146,12 +146,6 @@ defmodule Xgit.Repository.OnDisk do
     else
       {:error, reason} -> {:error, reason}
     end
-  end
-
-  defp create_branches_dir(git_dir) do
-    git_dir
-    |> Path.join("branches")
-    |> File.mkdir_p()
   end
 
   defp create_config(git_dir) do

--- a/test/support/test/on_disk_repo_test_case.ex
+++ b/test/support/test/on_disk_repo_test_case.ex
@@ -73,6 +73,7 @@ defmodule Xgit.Test.OnDiskRepoTestCase do
   defp git_init_and_standardize(git_dir, opts) do
     git_dir
     |> git_init()
+    |> remove_branches_dir()
     |> remove_sample_hooks()
     |> rewrite_config(Keyword.get(opts, :config_file_content, @default_config_file_content))
     |> rewrite_info_exclude()
@@ -80,6 +81,13 @@ defmodule Xgit.Test.OnDiskRepoTestCase do
 
   defp git_init(git_dir) do
     {_, 0} = System.cmd("git", ["init", git_dir])
+    git_dir
+  end
+
+  defp remove_branches_dir(git_dir) do
+    branches_dir = Path.join(git_dir, ".git/branches")
+    if File.dir?(branches_dir), do: File.rm_rf!(branches_dir)
+
     git_dir
   end
 


### PR DESCRIPTION
## Changes in This Pull Request
No longer create a `.git/branches` directory.

When creating reference versions of git repos for testing/comparison purposes, delete the existing `.git.branches` directory.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] There is test coverage for all changes.
- ~All cases where a literal value is returned use the `cover` macro to force code coverage.~ _n/a_
- ~Any code ported from jgit maintains all existing copyright and license notices.~ _n/a_
- ~If new files are ported from jgit, the path to the corresponding file(s) is included in the header comment.~ _n/a_
- ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
